### PR TITLE
test: update tests to support latest google-cloud-core

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -130,7 +130,7 @@ def system(session):
     session.install('mock', 'pytest')
     systest_deps = [
         'google-cloud-bigquery',
-        'google-cloud-pubsub',
+        'google-cloud-pubsub < 2.0.0',
         'google-cloud-storage',
         'google-cloud-testutils',
     ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.15.1"
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     "google-api-core[grpc] >= 1.15.0, < 2.0.0dev",
-    "google-cloud-core == 1.4.2rc1",
+    "google-cloud-core == 1.4.2rc2",
 ]
 extras = {
 }

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.15.1"
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     "google-api-core[grpc] >= 1.15.0, < 2.0.0dev",
-    "google-cloud-core >= 1.4.1, < 2.0dev",
+    "google-cloud-core == 1.4.2rc1",
 ]
 extras = {
 }

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.15.1"
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     "google-api-core[grpc] >= 1.15.0, < 2.0.0dev",
-    "google-cloud-core == 1.4.2rc2",
+    "google-cloud-core >= 1.4.1, < 2.0dev",
 ]
 extras = {
 }

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -49,10 +49,19 @@ class TestConnection(unittest.TestCase):
         self.assertIs(conn._client, client)
 
     def test_build_api_url_w_custom_endpoint(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         custom_endpoint = "https://foo-logging.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join([custom_endpoint, conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_extra_headers(self):
         import requests


### PR DESCRIPTION
`google-cloud-core` version 1.4.2 populates `prettyPrint=false` by
default. Update the connection tests to expect a value for
`prettyPrint`.

This PR also serves to test that the changes in googleapis/python-cloud-core#28 do not break this library.

Closes: #64.