### PR TITLE
docs: fix logger documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -345,10 +345,10 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
     "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
-    "grpc": ("https://grpc.io/grpc/python/", None),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
     "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
 }
 

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -43,12 +43,12 @@ _OUTBOUND_ENTRY_FIELDS = (  # (name, default)
 
 
 class Logger(object):
+    """Loggers represent named targets for log entries.
+
+    See https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs
+    """
     def __init__(self, name, client, *, labels=None):
-        """Loggers represent named targets for log entries.
-
-        See
-        https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs
-
+        """
         Args:
             name (str): The name of the logger.
             client (~logging_v2.client.Client):
@@ -56,7 +56,6 @@ class Logger(object):
                 for the logger (which requires a project).
             labels (Optional[dict]): Mapping of default labels for entries written
                 via this logger.
-
 
         """
         self.name = name
@@ -247,6 +246,7 @@ class Logger(object):
                     "organizations/[ORGANIZATION_ID]"
                     "billingAccounts/[BILLING_ACCOUNT_ID]"
                     "folders/[FOLDER_ID]"
+
                 If not passed, defaults to the project bound to the client.
             filter_ (Optional[str]): a filter expression. See
                 https://cloud.google.com/logging/docs/view/advanced_filters

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -47,6 +47,7 @@ class Logger(object):
 
     See https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs
     """
+
     def __init__(self, name, client, *, labels=None):
         """
         Args:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8822365/99719372-72bf3b80-2a69-11eb-9a78-179a9b7ea6de.png)

Verified that the docs show up locally by doing `nox -s docs`

Fixes #99  🦕