### PR TITLE
fix: remove duplicate stream handler

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -139,7 +139,6 @@ def setup_logging(
     logger = logging.getLogger()
     logger.setLevel(log_level)
     logger.addHandler(handler)
-    logger.addHandler(logging.StreamHandler())
     for logger_name in all_excluded_loggers:
         logger = logging.getLogger(logger_name)
         logger.propagate = False


### PR DESCRIPTION
Remove extra StreamHandler. This was resulting in duplicate logs showing up on many GCP environments.
I tested this manually on our supported environments, and removing this doesn't have any negative impacts, and makes GKE and GAE standard much more usable

Fixes https://github.com/googleapis/python-logging/issues/38 🦕
