### PR TITLE
fix: Remove keyword only argument for RequestsMiddleware

### DIFF
--- a/google/cloud/logging_v2/handlers/middleware/request.py
+++ b/google/cloud/logging_v2/handlers/middleware/request.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: NO COVER
 class RequestMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
 
-    def __init__(self, get_response=None):
+    def __init__(self, get_response):
         self.get_response = get_response
 
     def process_request(self, request):

--- a/google/cloud/logging_v2/handlers/middleware/request.py
+++ b/google/cloud/logging_v2/handlers/middleware/request.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: NO COVER
 class RequestMiddleware(MiddlewareMixin):
     """Saves the request in thread local"""
 
-    def __init__(self, *, get_response=None):
+    def __init__(self, get_response=None):
         self.get_response = get_response
 
     def process_request(self, request):

--- a/tests/unit/handlers/middleware/test_request.py
+++ b/tests/unit/handlers/middleware/test_request.py
@@ -54,6 +54,16 @@ class TestRequestMiddleware(DjangoBase):
         django_request = request._get_django_request()
         self.assertEqual(django_request, mock_request)
 
+    def test_can_instantiate_middleware_without_kwargs(self):
+        handler = mock.Mock()
+        middleware = self._make_one(handler)
+        self.assertEqual(middleware.get_response, handler)
+
+    def test_can_instantiate_middleware_with_kwargs(self):
+        handler = mock.Mock()
+        middleware = self._make_one(get_response=handler)
+        self.assertEqual(middleware.get_response, handler)
+
 
 class Test__get_django_request(DjangoBase):
     @staticmethod

--- a/tests/unit/handlers/middleware/test_request.py
+++ b/tests/unit/handlers/middleware/test_request.py
@@ -41,6 +41,9 @@ class TestRequestMiddleware(DjangoBase):
         return request.RequestMiddleware
 
     def _make_one(self, *args, **kw):
+        if not args and "get_response" not in kw:
+            kw["get_response"] = None
+
         return self._get_target_class()(*args, **kw)
 
     def test_process_request(self):

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -87,7 +87,7 @@ class Test_get_trace_id_from_django(unittest.TestCase):
 
         django_request = RequestFactory().get("/")
 
-        middleware = request.RequestMiddleware()
+        middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         trace_id = self._call_fut()
         self.assertIsNone(trace_id)
@@ -104,7 +104,7 @@ class Test_get_trace_id_from_django(unittest.TestCase):
             "/", **{django_trace_header: django_trace_id}
         )
 
-        middleware = request.RequestMiddleware()
+        middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         trace_id = self._call_fut()
 


### PR DESCRIPTION
Remove keyword only arguments from request middleware. This causes
django to fail when attempting to load middleware. Django currently only
supports handlers being passed in as args.

Fixes #112 🦕
