### PR TITLE
docs: fix handlers path import for CloudLoggingHandler

### DIFF
--- a/docs/snippets.py
+++ b/docs/snippets.py
@@ -361,7 +361,7 @@ def logging_handler(client):
     # [END create_default_handler]
 
     # [START create_cloud_handler]
-    from google.cloud.logging.handlers import CloudLoggingHandler
+    from google.cloud.logging_v2.handlers import CloudLoggingHandler
 
     handler = CloudLoggingHandler(client)
     cloud_logger = logging.getLogger("cloudLogger")

--- a/docs/stdlib-usage.rst
+++ b/docs/stdlib-usage.rst
@@ -10,7 +10,7 @@ Logging client.
 
     >>> import logging
     >>> import google.cloud.logging # Don't conflict with standard logging
-    >>> from google.cloud.logging.handlers import CloudLoggingHandler
+    >>> from google.cloud.logging_v2.handlers import CloudLoggingHandler
     >>> client = google.cloud.logging.Client()
     >>> handler = CloudLoggingHandler(client)
     >>> cloud_logger = logging.getLogger('cloudLogger')
@@ -42,7 +42,7 @@ this automatically:
 
     >>> import logging
     >>> import google.cloud.logging # Don't conflict with standard logging
-    >>> from google.cloud.logging.handlers import CloudLoggingHandler, setup_logging
+    >>> from google.cloud.logging_v2.handlers import CloudLoggingHandler, setup_logging
     >>> client = google.cloud.logging.Client()
     >>> handler = CloudLoggingHandler(client)
     >>> logging.getLogger().setLevel(logging.INFO) # defaults to WARN

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -297,7 +297,7 @@ Cloud Logging Handler
 If you prefer not to use
 :meth:`~google.cloud.logging.client.Client.get_default_handler`, you can
 directly create a
-:class:`~google.cloud.logging.handlers.handlers.CloudLoggingHandler` instance
+:class:`~google.cloud.logging_v2.handlers.CloudLoggingHandler` instance
 which will write directly to the API.
 
 .. literalinclude:: snippets.py
@@ -324,7 +324,7 @@ of the Python logger will be included in the structured log entry under the
 Cloud Logging Handler transports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :class:`~google.cloud.logging.handlers.handlers.CloudLoggingHandler`
+The :class:`~google.cloud.logging_v2.handlers.CloudLoggingHandler`
 logging handler can use different transports. The default is
 :class:`~google.cloud.logging.handlers.BackgroundThreadTransport`.
 
@@ -341,7 +341,7 @@ logging handler can use different transports. The default is
 fluentd logging handlers
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Besides :class:`~google.cloud.logging.handlers.handlers.CloudLoggingHandler`,
+Besides :class:`~google.cloud.logging_v2.handlers.CloudLoggingHandler`,
 which writes directly to the API, two other handlers are provided.
 :class:`~google.cloud.logging.handlers.app_engine.AppEngineHandler`, which is
 recommended when running on the Google App Engine Flexible vanilla runtimes


### PR DESCRIPTION
handlers is not accessible from`google.cloud.logging` :

```
>>> from google.cloud.logging.handlers import CloudLoggingHandler
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'google.cloud.logging.handlers'
```

Whereas it is from `google.cloud.logging_v2` :

```
>>> from google.cloud.logging_v2.handlers import CloudLoggingHandler
>>> 
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #115  🦕
