### PR TITLE
fix: Add submodule imports for handlers to logging alias

### DIFF
--- a/google/cloud/logging/handlers/__init__.py
+++ b/google/cloud/logging/handlers/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2016 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python :mod:`logging` handlers for Google Cloud Logging."""
+
+from google.cloud.logging_v2.handlers.app_engine import AppEngineHandler
+from google.cloud.logging_v2.handlers.container_engine import ContainerEngineHandler
+from google.cloud.logging_v2.handlers.handlers import CloudLoggingHandler
+from google.cloud.logging_v2.handlers.handlers import setup_logging
+
+__all__ = [
+    "AppEngineHandler",
+    "CloudLoggingHandler",
+    "ContainerEngineHandler",
+    "setup_logging",
+]

--- a/google/cloud/logging/handlers/middleware/__init__.py
+++ b/google/cloud/logging/handlers/middleware/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2017 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud.logging_v2.handlers.middleware.request import RequestMiddleware
+
+__all__ = ["RequestMiddleware"]

--- a/google/cloud/logging/handlers/transports/__init__.py
+++ b/google/cloud/logging/handlers/transports/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/google/cloud/logging/handlers/transports/__init__.py
+++ b/google/cloud/logging/handlers/transports/__init__.py
@@ -1,0 +1,29 @@
+
+# Copyright 2016 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transport classes for Python logging integration.
+Currently two options are provided, a synchronous transport that makes
+an API call for each log statement, and an asynchronous handler that
+sends the API using a :class:`~google.cloud.logging.logger.Batch` object in
+the background.
+"""
+
+from google.cloud.logging_v2.handlers.transports.base import Transport
+from google.cloud.logging_v2.handlers.transports.sync import SyncTransport
+from google.cloud.logging_v2.handlers.transports.background_thread import (
+    BackgroundThreadTransport,
+)
+
+__all__ = ["BackgroundThreadTransport", "SyncTransport", "Transport"]

--- a/tests/unit/test_logging_shim.py
+++ b/tests/unit/test_logging_shim.py
@@ -30,7 +30,7 @@ class TestLoggingShim(unittest.TestCase):
 
     def test_handler_shim_matches_logging_v2(self):
         from google.cloud.logging import handlers
-        from google.cloud.logging_v2 import handlers as handler_2
+        from google.cloud.logging_v2 import handlers as handlers_2
 
         self.assertEqual(handlers.__all__, handlers_2.__all__)
 

--- a/tests/unit/test_logging_shim.py
+++ b/tests/unit/test_logging_shim.py
@@ -26,7 +26,7 @@ class TestLoggingShim(unittest.TestCase):
         for name in logging.__all__:
             found = getattr(logging, name)
             expected = getattr(logging_v2, name)
-            if name == 'handlers':
+            if name == "handlers":
                 # handler has separate shim
                 self.assertTrue(found)
                 self.assertIs(type(found), type(expected))

--- a/tests/unit/test_logging_shim.py
+++ b/tests/unit/test_logging_shim.py
@@ -26,7 +26,13 @@ class TestLoggingShim(unittest.TestCase):
         for name in logging.__all__:
             found = getattr(logging, name)
             expected = getattr(logging_v2, name)
-            self.assertIs(found, expected)
+            if name == 'handlers':
+                # handler has separate shim
+                self.assertTrue(found)
+                self.assertIs(type(found), type(expected))
+            else:
+                # other attributes should be identical
+                self.assertIs(found, expected)
 
     def test_handler_shim_matches_logging_v2(self):
         from google.cloud.logging import handlers

--- a/tests/unit/test_logging_shim.py
+++ b/tests/unit/test_logging_shim.py
@@ -17,7 +17,7 @@ import unittest
 
 
 class TestLoggingShim(unittest.TestCase):
-    def test_shim_matches_logging_v2(self):
+    def test_root_shim_matches_logging_v2(self):
         from google.cloud import logging
         from google.cloud import logging_v2
 
@@ -26,4 +26,37 @@ class TestLoggingShim(unittest.TestCase):
         for name in logging.__all__:
             found = getattr(logging, name)
             expected = getattr(logging_v2, name)
+            self.assertIs(found, expected)
+
+    def test_handler_shim_matches_logging_v2(self):
+        from google.cloud.logging import handlers
+        from google.cloud.logging_v2 import handlers as handler_2
+
+        self.assertEqual(handlers.__all__, handlers_2.__all__)
+
+        for name in handlers.__all__:
+            found = getattr(handlers, name)
+            expected = getattr(handlers_2, name)
+            self.assertIs(found, expected)
+
+    def test_middleware_shim_matches_logging_v2(self):
+        from google.cloud.logging.handlers import middleware
+        from google.cloud.logging_v2.handlers import middleware as middleware_2
+
+        self.assertEqual(middleware.__all__, middleware_2.__all__)
+
+        for name in middleware.__all__:
+            found = getattr(middleware, name)
+            expected = getattr(middleware_2, name)
+            self.assertIs(found, expected)
+
+    def test_transports_shim_matches_logging_v2(self):
+        from google.cloud.logging.handlers import transports
+        from google.cloud.logging_v2.handlers import transports as transports_2
+
+        self.assertEqual(transports.__all__, transports_2.__all__)
+
+        for name in transports.__all__:
+            found = getattr(transports, name)
+            expected = getattr(transports_2, name)
             self.assertIs(found, expected)


### PR DESCRIPTION
We give users two packages: `logging_v2` for the current version of the library, and `logging` as the alias. 

We found the alias was only exporting paths at the library root, which was not what users expected. This meant they could not run 
```from google.cloud.logging.handlers import CloudLoggingHandler```.

Instead they had to run 
```
from google.cloud.logging import handlers
handlers.CloudLoggingHandler
```

This PR adds more `__init__.py` files to advertise sub-modules for the handlers. I avoided doing the same for the gapic directories (`/proto`, `/services`, `/types`) because we want to discourage end-users from using auto-generated code



Fixes https://github.com/googleapis/python-logging/issues/115 🦕
