### PR TITLE
feat: support http_request field

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -115,7 +115,7 @@ def get_request_data_from_django():
 
 def get_request_data():
     """Helper to get trace_id and http_request data from supported web
-    frameworks.
+    frameworks (currently supported: Flask and Django).
 
     Returns:
         str: TraceID in HTTP request headers.

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -62,10 +62,11 @@ def get_request_data_from_flask():
         return None, None
 
     # build http_request
+    length = flask.request.content_length
     http_request = {
         "request_method": flask.request.method,
         "request_url": flask.request.url,
-        "request_size": str(flask.request.content_length),
+        "request_size": str(length) if length else None,
         "user_agent": flask.request.user_agent.string,
         "remote_ip": flask.request.remote_addr,
         "referer": flask.request.referrer,

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -58,6 +58,8 @@ def get_request_data_from_flask():
         str: TraceID in HTTP request headers.
         HttpRequest: data about the associated http request.
     """
+    if flask is None or not flask.request:
+        return None, None
 
     # build http_request
     http_request = HttpRequest(

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -30,6 +30,7 @@ _DJANGO_USERAGENT_HEADER = "HTTP_USER_AGENT"
 _DJANGO_REMOTE_ADDR_HEADER = "REMOTE_ADDR"
 _DJANGO_REFERER_HEADER = "HTTP_REFERER"
 _FLASK_TRACE_HEADER = "X_CLOUD_TRACE_CONTEXT"
+_PROTOCOL_HEADER = "SERVER_PROTOCOL"
 
 
 def format_stackdriver_json(record, message):
@@ -68,6 +69,7 @@ def get_request_data_from_flask():
         "user_agent": flask.request.user_agent.string,
         "remote_ip": flask.request.remote_addr,
         "referer": flask.request.referrer,
+        "protocol": request.environ.get(_PROTOCOL_HEADER)
     }
 
     # find trace id
@@ -99,6 +101,7 @@ def get_request_data_from_django():
         "user_agent": request.META.get(_DJANGO_USERAGENT_HEADER),
         "remote_ip": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
         "referer": request.META.get(_DJANGO_REFERER_HEADER),
+        "protocol": request.META.get(_PROTOCOL_HEADER),
     }
 
     # find trace id

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -63,8 +63,8 @@ def get_request_data_from_flask():
     # build http_request
     http_request = {
         'request_method': flask.request.method,
-        'request_url': flask.request.host_url,
-        'request_size': flask.request.content_length,
+        'request_url': flask.request.url,
+        'request_size': str(flask.request.content_length),
         'user_agent': flask.request.user_agent.string,
         'remote_ip': flask.request.remote_addr,
         'referer': flask.request.referrer,

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -93,7 +93,7 @@ def get_request_data_from_django():
     # build http_request
     http_request = {
         'request_method': request.method,
-        'request_url': request.get_full_path(),
+        'request_url': request.build_absolute_uri(),
         'request_size': request.META.get(_DJANGO_LENGTH_HEADER),
         'user_agent': request.META.get(_DJANGO_USERAGENT_HEADER),
         'remote_ip': request.META.get(_DJANGO_REMOTE_ADDR_HEADER),

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -51,10 +51,11 @@ def format_stackdriver_json(record, message):
 
 
 def get_request_data_from_flask():
-    """Get trace_id from flask request headers.
+    """Get trace_id and http_request data from flask request headers.
 
     Returns:
         str: TraceID in HTTP request headers.
+        dict: data about the associated http request.
     """
     if flask is None or not flask.request:
         return None, None
@@ -78,10 +79,11 @@ def get_request_data_from_flask():
     return trace_id, http_request
 
 def get_request_data_from_django():
-    """Get trace_id from django request headers.
+    """Get trace_id and http_request data from django request headers.
 
     Returns:
         str: TraceID in HTTP request headers.
+        dict: data about the associated http request.
     """
     request = _get_django_request()
 
@@ -109,10 +111,12 @@ def get_request_data_from_django():
 
 
 def get_request_data():
-    """Helper to get trace_id from web application request header.
+    """Helper to get trace_id and http_request data from supported web
+    frameworks.
 
     Returns:
         str: TraceID in HTTP request headers.
+        dict: data about the associated http request.
     """
     checkers = (
         get_request_data_from_django,
@@ -121,7 +125,7 @@ def get_request_data():
 
     for checker in checkers:
         trace_id, http_request = checker()
-        if trace_id is not None:
+        if http_request is not None:
             return trace_id, http_request
 
-    return None
+    return None, None

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -64,6 +64,24 @@ def get_trace_id_from_flask():
 
     return trace_id
 
+def get_http_request_from_flask():
+    """Get trace_id from flask request headers.
+
+    Returns:
+        str: TraceID in HTTP request headers.
+    """
+    if flask is None or not flask.request:
+        return None
+
+    obj = {'request_method':flask.request.method,
+            'request_url': flask.request.host_url,
+            'request_size': flask.request.content_length,
+            'user_agent': flask.request.user_agent.string,
+            'remote_ip': flask.request.remote_addr,
+            'referer': flask.request.referrer,
+            }
+
+    return obj
 
 def get_trace_id_from_django():
     """Get trace_id from django request headers.
@@ -100,5 +118,23 @@ def get_trace_id():
         trace_id = checker()
         if trace_id is not None:
             return trace_id
+
+    return None
+
+
+def get_http_request_data():
+    """Helper to get trace_id from web application request header.
+
+    Returns:
+        str: TraceID in HTTP request headers.
+    """
+    checkers = (
+        get_http_request_from_flask,
+    )
+
+    for checker in checkers:
+        obj = checker()
+        if obj  is not None:
+            return obj
 
     return None

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -52,11 +52,12 @@ def format_stackdriver_json(record, message):
 
 
 def get_request_data_from_flask():
-    """Get trace_id and http_request data from flask request headers.
+    """Get http_request and trace data from flask request headers.
 
     Returns:
-        str: TraceID in HTTP request headers.
-        HttpRequest: data about the associated http request.
+        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+            Data related to the current http request and the trace_id for the
+            request. Both fields will be None if a flask request isn't found.
     """
     if flask is None or not flask.request:
         return None, None
@@ -82,11 +83,12 @@ def get_request_data_from_flask():
 
 
 def get_request_data_from_django():
-    """Get trace_id and http_request data from django request headers.
+    """Get http_request and trace data from django request headers.
 
     Returns:
-        str: TraceID in HTTP request headers.
-        HttpRequest: data about the associated http request.
+        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+            Data related to the current http request and the trace_id for the
+            request. Both fields will be None if a django request isn't found.
     """
     request = _get_django_request()
 
@@ -113,12 +115,13 @@ def get_request_data_from_django():
 
 
 def get_request_data():
-    """Helper to get trace_id and http_request data from supported web
+    """Helper to get http_request and trace data from supported web
     frameworks (currently supported: Flask and Django).
 
     Returns:
-        str: TraceID in HTTP request headers.
-        HttpRequest: data about the associated http request.
+        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+            Data related to the current http request and the trace_id for the
+            request. Both fields will be None if a supported web request isn't found.
     """
     checkers = (
         get_request_data_from_django,

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -76,7 +76,7 @@ def get_request_data_from_flask():
     if header:
         trace_id = header.split("/", 1)[0]
 
-    return trace_id, http_request
+    return http_request, trace_id
 
 def get_request_data_from_django():
     """Get trace_id and http_request data from django request headers.
@@ -106,7 +106,7 @@ def get_request_data_from_django():
     if header:
         trace_id = header.split("/", 1)[0]
 
-    return trace_id, http_request
+    return http_request, trace_id
 
 
 
@@ -124,8 +124,8 @@ def get_request_data():
     )
 
     for checker in checkers:
-        trace_id, http_request = checker()
+        http_request, trace_id = checker()
         if http_request is not None:
-            return trace_id, http_request
+            return http_request, trace_id
 
     return None, None

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -69,7 +69,7 @@ def get_request_data_from_flask():
         "user_agent": flask.request.user_agent.string,
         "remote_ip": flask.request.remote_addr,
         "referer": flask.request.referrer,
-        "protocol": request.environ.get(_PROTOCOL_HEADER)
+        "protocol": flask.request.environ.get(_PROTOCOL_HEADER)
     }
 
     # find trace id

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -70,7 +70,7 @@ def get_request_data_from_flask():
         "user_agent": flask.request.user_agent.string,
         "remote_ip": flask.request.remote_addr,
         "referer": flask.request.referrer,
-        "protocol": flask.request.environ.get(_PROTOCOL_HEADER)
+        "protocol": flask.request.environ.get(_PROTOCOL_HEADER),
     }
 
     # find trace id

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -62,12 +62,12 @@ def get_request_data_from_flask():
 
     # build http_request
     http_request = {
-        'request_method': flask.request.method,
-        'request_url': flask.request.url,
-        'request_size': str(flask.request.content_length),
-        'user_agent': flask.request.user_agent.string,
-        'remote_ip': flask.request.remote_addr,
-        'referer': flask.request.referrer,
+        "request_method": flask.request.method,
+        "request_url": flask.request.url,
+        "request_size": str(flask.request.content_length),
+        "user_agent": flask.request.user_agent.string,
+        "remote_ip": flask.request.remote_addr,
+        "referer": flask.request.referrer,
     }
 
     # find trace id
@@ -77,6 +77,7 @@ def get_request_data_from_flask():
         trace_id = header.split("/", 1)[0]
 
     return http_request, trace_id
+
 
 def get_request_data_from_django():
     """Get trace_id and http_request data from django request headers.
@@ -92,12 +93,12 @@ def get_request_data_from_django():
 
     # build http_request
     http_request = {
-        'request_method': request.method,
-        'request_url': request.build_absolute_uri(),
-        'request_size': request.META.get(_DJANGO_LENGTH_HEADER),
-        'user_agent': request.META.get(_DJANGO_USERAGENT_HEADER),
-        'remote_ip': request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
-        'referer': request.META.get(_DJANGO_REFERER_HEADER),
+        "request_method": request.method,
+        "request_url": request.build_absolute_uri(),
+        "request_size": request.META.get(_DJANGO_LENGTH_HEADER),
+        "user_agent": request.META.get(_DJANGO_USERAGENT_HEADER),
+        "remote_ip": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
+        "referer": request.META.get(_DJANGO_REFERER_HEADER),
     }
 
     # find trace id
@@ -107,7 +108,6 @@ def get_request_data_from_django():
         trace_id = header.split("/", 1)[0]
 
     return http_request, trace_id
-
 
 
 def get_request_data():

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -21,8 +21,7 @@ and labels for App Engine logs.
 import logging
 import os
 
-from google.cloud.logging_v2.handlers._helpers import get_trace_id
-from google.cloud.logging_v2.handlers._helpers import get_http_request_data
+from google.cloud.logging_v2.handlers._helpers import get_request_data
 from google.cloud.logging_v2.handlers.transports import BackgroundThreadTransport
 from google.cloud.logging_v2.resource import Resource
 
@@ -97,7 +96,7 @@ class AppEngineHandler(logging.StreamHandler):
         """
         gae_labels = {}
 
-        trace_id = get_trace_id()
+        trace_id, _ = get_request_data()
         if trace_id is not None:
             gae_labels[_TRACE_ID_LABEL] = trace_id
 
@@ -115,12 +114,9 @@ class AppEngineHandler(logging.StreamHandler):
         """
         message = super(AppEngineHandler, self).format(record)
         gae_labels = self.get_gae_labels()
-        trace_id = (
-            "projects/%s/traces/%s" % (self.project_id, gae_labels[_TRACE_ID_LABEL])
-            if _TRACE_ID_LABEL in gae_labels
-            else None
-        )
-        http_request = get_http_request_data()
+        trace_id, http_request = get_request_data()
+        if trace_id is not None:
+            trace_id = f"projects/{self.project_id}/{trace_id}"
         self.transport.send(
             record, message, resource=self.resource, labels=gae_labels,
             trace=trace_id, http_request=http_request,

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -22,6 +22,7 @@ import logging
 import os
 
 from google.cloud.logging_v2.handlers._helpers import get_trace_id
+from google.cloud.logging_v2.handlers._helpers import get_http_request_data
 from google.cloud.logging_v2.handlers.transports import BackgroundThreadTransport
 from google.cloud.logging_v2.resource import Resource
 
@@ -119,6 +120,8 @@ class AppEngineHandler(logging.StreamHandler):
             if _TRACE_ID_LABEL in gae_labels
             else None
         )
+        http_request = get_http_request_data()
         self.transport.send(
-            record, message, resource=self.resource, labels=gae_labels, trace=trace_id
+            record, message, resource=self.resource, labels=gae_labels,
+            trace=trace_id, http_request=http_request,
         )

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -118,6 +118,10 @@ class AppEngineHandler(logging.StreamHandler):
         if trace_id is not None:
             trace_id = f"projects/{self.project_id}/{trace_id}"
         self.transport.send(
-            record, message, resource=self.resource, labels=gae_labels,
-            trace=trace_id, http_request=http_request,
+            record,
+            message,
+            resource=self.resource,
+            labels=gae_labels,
+            trace=trace_id,
+            http_request=http_request,
         )

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -96,7 +96,7 @@ class AppEngineHandler(logging.StreamHandler):
         """
         gae_labels = {}
 
-        trace_id, _ = get_request_data()
+        _, trace_id = get_request_data()
         if trace_id is not None:
             gae_labels[_TRACE_ID_LABEL] = trace_id
 
@@ -114,7 +114,7 @@ class AppEngineHandler(logging.StreamHandler):
         """
         message = super(AppEngineHandler, self).format(record)
         gae_labels = self.get_gae_labels()
-        trace_id, http_request = get_request_data()
+        http_request, trace_id = get_request_data()
         if trace_id is not None:
             trace_id = f"projects/{self.project_id}/{trace_id}"
         self.transport.send(

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -116,7 +116,7 @@ class AppEngineHandler(logging.StreamHandler):
         gae_labels = self.get_gae_labels()
         http_request, trace_id = get_request_data()
         if trace_id is not None:
-            trace_id = f"projects/{self.project_id}/{trace_id}"
+            trace_id = f"projects/{self.project_id}/traces/{trace_id}"
         self.transport.send(
             record,
             message,

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -297,7 +297,7 @@ class BackgroundThreadTransport(Transport):
 
     def send(
         self, record, message, resource=None, labels=None, trace=None,
-        span_id=None, , http_request=None
+        span_id=None, http_request=None
     ):
         """Overrides Transport.send().
 

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -222,12 +222,7 @@ class _Worker(object):
                 file=sys.stderr,
             )
 
-    def enqueue(
-        self,
-        record,
-        message,
-        **kwargs,
-    ):
+    def enqueue(self, record, message, **kwargs):
         """Queues a log entry to be written by the background thread.
 
         Args:
@@ -286,12 +281,7 @@ class BackgroundThreadTransport(Transport):
         )
         self.worker.start()
 
-    def send(
-        self,
-        record,
-        message,
-        **kwargs,
-    ):
+    def send(self, record, message, **kwargs):
         """Overrides Transport.send().
 
         Args:
@@ -300,11 +290,7 @@ class BackgroundThreadTransport(Transport):
                 formatted by the associated log formatters.
             **kwargs: Additional optional arguments for the logger
         """
-        self.worker.enqueue(
-            record,
-            message,
-            **kwargs,
-        )
+        self.worker.enqueue(record, message, **kwargs)
 
     def flush(self):
         """Submit any pending log records."""

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -229,7 +229,7 @@ class _Worker(object):
             record (logging.LogRecord): Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                         formatted by the associated log formatters.
-            **kwargs: Additional optional arguments for the logger
+            kwargs: Additional optional arguments for the logger
         """
         queue_entry = {
             "info": {"message": message, "python_logger": record.name},
@@ -288,7 +288,7 @@ class BackgroundThreadTransport(Transport):
             record (logging.LogRecord): Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                 formatted by the associated log formatters.
-            **kwargs: Additional optional arguments for the logger
+            kwargs: Additional optional arguments for the logger
         """
         self.worker.enqueue(record, message, **kwargs)
 

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -223,8 +223,15 @@ class _Worker(object):
             )
 
     def enqueue(
-        self, record, message, *, resource=None, labels=None, trace=None,
-        span_id=None, http_request=None
+        self,
+        record,
+        message,
+        *,
+        resource=None,
+        labels=None,
+        trace=None,
+        span_id=None,
+        http_request=None,
     ):
         """Queues a log entry to be written by the background thread.
 
@@ -249,7 +256,7 @@ class _Worker(object):
             "trace": trace,
             "span_id": span_id,
             "timestamp": datetime.datetime.utcfromtimestamp(record.created),
-            "http_request": http_request
+            "http_request": http_request,
         }
         self._queue.put_nowait(queue_entry)
 
@@ -296,8 +303,14 @@ class BackgroundThreadTransport(Transport):
         self.worker.start()
 
     def send(
-        self, record, message, resource=None, labels=None, trace=None,
-        span_id=None, http_request=None
+        self,
+        record,
+        message,
+        resource=None,
+        labels=None,
+        trace=None,
+        span_id=None,
+        http_request=None,
     ):
         """Overrides Transport.send().
 

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -23,7 +23,8 @@ class Transport(object):
     """
 
     def send(
-        self, record, message, *, resource=None, labels=None, trace=None, span_id=None
+        self, record, message, *, resource=None, labels=None, trace=None,
+        span_id=None, http_request=None
     ):
         """Transport send to be implemented by subclasses.
 

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -23,8 +23,15 @@ class Transport(object):
     """
 
     def send(
-        self, record, message, *, resource=None, labels=None, trace=None,
-        span_id=None, http_request=None
+        self,
+        record,
+        message,
+        *,
+        resource=None,
+        labels=None,
+        trace=None,
+        span_id=None,
+        http_request=None
     ):
         """Transport send to be implemented by subclasses.
 

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -26,12 +26,7 @@ class Transport(object):
         self,
         record,
         message,
-        *,
-        resource=None,
-        labels=None,
-        trace=None,
-        span_id=None,
-        http_request=None
+        **kwargs,
     ):
         """Transport send to be implemented by subclasses.
 
@@ -39,9 +34,7 @@ class Transport(object):
             record (logging.LogRecord): Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                 formatted by the associated log formatters.
-            resource (Optional[google.cloud.logging_v2.resource.Resource]):
-                 Monitored resource of the entry.
-            labels (Optional[dict]): Mapping of labels for the entry.
+            **kwargs: Additional optional arguments for the logger
         """
         raise NotImplementedError
 

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -22,12 +22,7 @@ class Transport(object):
     client and name object, and must override :meth:`send`.
     """
 
-    def send(
-        self,
-        record,
-        message,
-        **kwargs,
-    ):
+    def send(self, record, message, **kwargs):
         """Transport send to be implemented by subclasses.
 
         Args:

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -29,7 +29,7 @@ class Transport(object):
             record (logging.LogRecord): Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                 formatted by the associated log formatters.
-            **kwargs: Additional optional arguments for the logger
+            kwargs: Additional optional arguments for the logger
         """
         raise NotImplementedError
 

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -31,7 +31,8 @@ class SyncTransport(Transport):
         self.logger = client.logger(name)
 
     def send(
-        self, record, message, *, resource=None, labels=None, trace=None, span_id=None
+        self, record, message, *, resource=None, labels=None, trace=None,
+        span_id=None, http_request=None,
     ):
         """Overrides transport.send().
 
@@ -43,6 +44,8 @@ class SyncTransport(Transport):
             resource (Optional[~logging_v2.resource.Resource]):
                  Monitored resource of the entry.
             labels (Optional[dict]): Mapping of labels for the entry.
+            http_request (Optional[dict]): Info about HTTP request associated
+                 with the entry.
         """
         info = {"message": message, "python_logger": record.name}
         self.logger.log_struct(
@@ -52,4 +55,5 @@ class SyncTransport(Transport):
             labels=labels,
             trace=trace,
             span_id=span_id,
+            http_request=http_request,
         )

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -30,12 +30,7 @@ class SyncTransport(Transport):
     def __init__(self, client, name):
         self.logger = client.logger(name)
 
-    def send(
-        self,
-        record,
-        message,
-        **kwargs,
-    ):
+    def send(self, record, message, **kwargs):
         """Overrides transport.send().
 
         Args:
@@ -47,7 +42,5 @@ class SyncTransport(Transport):
         """
         info = {"message": message, "python_logger": record.name}
         self.logger.log_struct(
-            info,
-            severity=_helpers._normalize_severity(record.levelno),
-            **kwargs,
+            info, severity=_helpers._normalize_severity(record.levelno), **kwargs,
         )

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -34,12 +34,7 @@ class SyncTransport(Transport):
         self,
         record,
         message,
-        *,
-        resource=None,
-        labels=None,
-        trace=None,
-        span_id=None,
-        http_request=None,
+        **kwargs,
     ):
         """Overrides transport.send().
 
@@ -48,19 +43,11 @@ class SyncTransport(Transport):
                 Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                 formatted by the associated log formatters.
-            resource (Optional[~logging_v2.resource.Resource]):
-                 Monitored resource of the entry.
-            labels (Optional[dict]): Mapping of labels for the entry.
-            http_request (Optional[dict]): Info about HTTP request associated
-                 with the entry.
+            **kwargs: Additional optional arguments for the logger
         """
         info = {"message": message, "python_logger": record.name}
         self.logger.log_struct(
             info,
             severity=_helpers._normalize_severity(record.levelno),
-            resource=resource,
-            labels=labels,
-            trace=trace,
-            span_id=span_id,
-            http_request=http_request,
+            **kwargs,
         )

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -38,7 +38,7 @@ class SyncTransport(Transport):
                 Python log record that the handler was called with.
             message (str): The message from the ``LogRecord`` after being
                 formatted by the associated log formatters.
-            **kwargs: Additional optional arguments for the logger
+            kwargs: Additional optional arguments for the logger
         """
         info = {"message": message, "python_logger": record.name}
         self.logger.log_struct(

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -31,8 +31,15 @@ class SyncTransport(Transport):
         self.logger = client.logger(name)
 
     def send(
-        self, record, message, *, resource=None, labels=None, trace=None,
-        span_id=None, http_request=None,
+        self,
+        record,
+        message,
+        *,
+        resource=None,
+        labels=None,
+        trace=None,
+        span_id=None,
+        http_request=None,
     ):
         """Overrides transport.send().
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -283,3 +283,7 @@ class Test_get_request_data(unittest.TestCase):
 
         django_mock.assert_called_once_with()
         flask_mock.assert_called_once_with()
+
+    def test_wo_libraries(self):
+        output = self._call_fut()
+        self.assertEqual(output, (None, None))

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -27,6 +27,7 @@ _HTTP_REQUEST_FIELDS = [
     "user_agent",
     "remote_ip",
     "referer",
+    "protocol",
 ]
 
 
@@ -107,6 +108,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertEqual(http_request["referer"], expected_referrer)
         self.assertEqual(http_request["remote_ip"], expected_ip)
         self.assertEqual(http_request["request_size"], str(len(body_content)))
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
 
 
@@ -193,6 +195,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         self.assertEqual(http_request["referer"], expected_referrer)
         self.assertEqual(http_request["remote_ip"], "127.0.0.1")
         self.assertEqual(http_request["request_size"], str(len(body_content)))
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
 
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -78,7 +78,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
 
-    def test_http_data(self):
+    def test_http_request_auto_populated(self):
         expected_path = "http://testserver/123"
         expected_agent = "Mozilla/5.0"
         expected_referrer = "self"
@@ -166,7 +166,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         for field in _HTTP_REQUEST_FIELDS:
             self.assertTrue(field in http_request)
 
-    def test_http_data(self):
+    def test_http_request_auto_populated(self):
         from django.test import RequestFactory
         from google.cloud.logging_v2.handlers.middleware import request
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -16,12 +16,19 @@ import unittest
 
 import mock
 
-_FLASK_TRACE_ID = 'flask-id'
-_FLASK_HTTP_REQUEST = {'request_url': "https://flask.palletsprojects.com/en/1.1.x/"}
-_DJANGO_TRACE_ID = 'django-id'
-_DJANGO_HTTP_REQUEST = {'request_url': "https://www.djangoproject.com/"}
-_HTTP_REQUEST_FIELDS = ['request_method', 'request_url', 'request_size', 
-                        'user_agent', 'remote_ip', 'referer']
+_FLASK_TRACE_ID = "flask-id"
+_FLASK_HTTP_REQUEST = {"request_url": "https://flask.palletsprojects.com/en/1.1.x/"}
+_DJANGO_TRACE_ID = "django-id"
+_DJANGO_HTTP_REQUEST = {"request_url": "https://www.djangoproject.com/"}
+_HTTP_REQUEST_FIELDS = [
+    "request_method",
+    "request_url",
+    "request_size",
+    "user_agent",
+    "remote_ip",
+    "referer",
+]
+
 
 class Test_get_request_data_from_flask(unittest.TestCase):
     @staticmethod
@@ -48,7 +55,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertIsNone(trace_id)
-        self.assertEqual(http_request['request_method'], "GET")
+        self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
         for field in _HTTP_REQUEST_FIELDS:
             self.assertTrue(field in http_request)
@@ -67,36 +74,41 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request['request_method'], "GET")
+        self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
         for field in _HTTP_REQUEST_FIELDS:
             self.assertTrue(field in http_request)
 
     def test_http_data(self):
-        expected_path = 'http://testserver/123'
-        expected_agent = 'Mozilla/5.0'
+        expected_path = "http://testserver/123"
+        expected_agent = "Mozilla/5.0"
         expected_referrer = "self"
         expected_ip = "10.1.2.3"
-        body_content = 'test'
-        headers = {'User-Agent': expected_agent,
-                   'Referer': expected_referrer,
-                   'HTTP_X_FORWARDED_FOR': '0.0.0.0'}
+        body_content = "test"
+        headers = {
+            "User-Agent": expected_agent,
+            "Referer": expected_referrer,
+            "HTTP_X_FORWARDED_FOR": "0.0.0.0",
+        }
 
         app = self.create_app()
         with app.test_client() as c:
-            c.put(path=expected_path,
-                  data=body_content,
-                  environ_base={'REMOTE_ADDR': expected_ip},
-                  headers=headers)
+            c.put(
+                path=expected_path,
+                data=body_content,
+                environ_base={"REMOTE_ADDR": expected_ip},
+                headers=headers,
+            )
             http_request, trace_id = self._call_fut()
 
-        self.assertEqual(http_request['request_method'], "PUT")
-        self.assertEqual(http_request['request_url'], expected_path)
-        self.assertEqual(http_request['user_agent'], expected_agent)
-        self.assertEqual(http_request['referer'], expected_referrer)
-        self.assertEqual(http_request['remote_ip'], expected_ip)
-        self.assertEqual(http_request['request_size'], str(len(body_content)))
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["referer"], expected_referrer)
+        self.assertEqual(http_request["remote_ip"], expected_ip)
+        self.assertEqual(http_request["request_size"], str(len(body_content)))
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+
 
 class Test_get_request_data_from_django(unittest.TestCase):
     @staticmethod
@@ -129,7 +141,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request['request_method'], "GET")
+        self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
         for field in _HTTP_REQUEST_FIELDS:
             self.assertTrue(field in http_request)
@@ -152,7 +164,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request['request_method'], "GET")
+        self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
         for field in _HTTP_REQUEST_FIELDS:
             self.assertTrue(field in http_request)
@@ -160,26 +172,29 @@ class Test_get_request_data_from_django(unittest.TestCase):
     def test_http_data(self):
         from django.test import RequestFactory
         from google.cloud.logging_v2.handlers.middleware import request
-        expected_path = 'http://testserver/123'
-        expected_agent = 'Mozilla/5.0'
+
+        expected_path = "http://testserver/123"
+        expected_agent = "Mozilla/5.0"
         expected_referrer = "self"
-        body_content = 'test'
+        body_content = "test"
         django_request = RequestFactory().put(
             expected_path,
             data=body_content,
             HTTP_USER_AGENT=expected_agent,
-            HTTP_REFERER=expected_referrer)
+            HTTP_REFERER=expected_referrer,
+        )
 
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request['request_method'], "PUT")
-        self.assertEqual(http_request['request_url'], expected_path)
-        self.assertEqual(http_request['user_agent'], expected_agent)
-        self.assertEqual(http_request['referer'], expected_referrer)
-        self.assertEqual(http_request['remote_ip'], '127.0.0.1')
-        self.assertEqual(http_request['request_size'], str(len(body_content)))
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["referer"], expected_referrer)
+        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
+        self.assertEqual(http_request["request_size"], str(len(body_content)))
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+
 
 class Test_get_request_data(unittest.TestCase):
     @staticmethod
@@ -256,7 +271,6 @@ class Test_get_request_data(unittest.TestCase):
 
         django_mock.assert_called_once_with()
         flask_mock.assert_called_once_with()
-
 
     def test_missing_both(self):
         flask_expected = (None, None)

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -20,15 +20,6 @@ _FLASK_TRACE_ID = "flask-id"
 _FLASK_HTTP_REQUEST = {"request_url": "https://flask.palletsprojects.com/en/1.1.x/"}
 _DJANGO_TRACE_ID = "django-id"
 _DJANGO_HTTP_REQUEST = {"request_url": "https://www.djangoproject.com/"}
-_HTTP_REQUEST_FIELDS = [
-    "request_method",
-    "request_url",
-    "request_size",
-    "user_agent",
-    "remote_ip",
-    "referer",
-    "protocol",
-]
 
 
 class Test_get_request_data_from_flask(unittest.TestCase):
@@ -56,10 +47,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertIsNone(trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
-        for field in _HTTP_REQUEST_FIELDS:
-            self.assertTrue(field in http_request)
+        self.assertEqual(http_request.request_method, "GET")
 
     def test_valid_context_header(self):
         flask_trace_header = "X_CLOUD_TRACE_CONTEXT"
@@ -75,8 +63,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "GET")
 
     def test_http_request_populated(self):
         expected_path = "http://testserver/123"
@@ -99,14 +86,13 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             )
             http_request, trace_id = self._call_fut()
 
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["user_agent"], expected_agent)
-        self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remote_ip"], expected_ip)
-        self.assertEqual(http_request["request_size"], str(len(body_content)))
-        self.assertEqual(http_request["protocol"], "HTTP/1.1")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "PUT")
+        self.assertEqual(http_request.request_url, expected_path)
+        self.assertEqual(http_request.user_agent, expected_agent)
+        self.assertEqual(http_request.referer, expected_referrer)
+        self.assertEqual(http_request.remote_ip, expected_ip)
+        self.assertEqual(http_request.request_size, len(body_content))
+        self.assertEqual(http_request.protocol, "HTTP/1.1")
 
     def test_http_request_sparse(self):
         expected_path = "http://testserver/123"
@@ -114,12 +100,9 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         with app.test_client() as c:
             c.put(path=expected_path)
             http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["protocol"], "HTTP/1.1")
-        self.assertIsNone(http_request["referer"])
-        self.assertIsNone(http_request["request_size"])
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "PUT")
+        self.assertEqual(http_request.request_url, expected_path)
+        self.assertEqual(http_request.protocol, "HTTP/1.1")
 
 
 class Test_get_request_data_from_django(unittest.TestCase):
@@ -153,8 +136,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "GET")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "GET")
         self.assertIsNone(trace_id)
 
     def test_valid_context_header(self):
@@ -174,10 +156,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
-        for field in _HTTP_REQUEST_FIELDS:
-            self.assertTrue(field in http_request)
+        self.assertEqual(http_request.request_method, "GET")
 
     def test_http_request_populated(self):
         from django.test import RequestFactory
@@ -197,14 +176,13 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["user_agent"], expected_agent)
-        self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
-        self.assertEqual(http_request["request_size"], str(len(body_content)))
-        self.assertEqual(http_request["protocol"], "HTTP/1.1")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "PUT")
+        self.assertEqual(http_request.request_url, expected_path)
+        self.assertEqual(http_request.user_agent, expected_agent)
+        self.assertEqual(http_request.referer, expected_referrer)
+        self.assertEqual(http_request.remote_ip, "127.0.0.1")
+        self.assertEqual(http_request.request_size, len(body_content))
+        self.assertEqual(http_request.protocol, "HTTP/1.1")
 
     def test_http_request_sparse(self):
         from django.test import RequestFactory
@@ -215,13 +193,10 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertIsNone(http_request["referer"])
-        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
-        self.assertIsNone(http_request["request_size"])
-        self.assertEqual(http_request["protocol"], "HTTP/1.1")
-        self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
+        self.assertEqual(http_request.request_method, "PUT")
+        self.assertEqual(http_request.request_url, expected_path)
+        self.assertEqual(http_request.remote_ip, "127.0.0.1")
+        self.assertEqual(http_request.protocol, "HTTP/1.1")
 
 
 class Test_get_request_data(unittest.TestCase):

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -77,8 +77,6 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertEqual(trace_id, expected_trace_id)
         self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
-        for field in _HTTP_REQUEST_FIELDS:
-            self.assertTrue(field in http_request)
 
     def test_http_data(self):
         expected_path = "http://testserver/123"
@@ -89,7 +87,6 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         headers = {
             "User-Agent": expected_agent,
             "Referer": expected_referrer,
-            "HTTP_X_FORWARDED_FOR": "0.0.0.0",
         }
 
         app = self.create_app()
@@ -145,8 +142,6 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, trace_id = self._call_fut()
         self.assertEqual(http_request["request_method"], "GET")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
-        for field in _HTTP_REQUEST_FIELDS:
-            self.assertTrue(field in http_request)
         self.assertIsNone(trace_id)
 
     def test_valid_context_header(self):

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -121,6 +121,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertIsNone(http_request["request_size"])
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
 
+
 class Test_get_request_data_from_django(unittest.TestCase):
     @staticmethod
     def _call_fut():
@@ -221,7 +222,6 @@ class Test_get_request_data_from_django(unittest.TestCase):
         self.assertIsNone(http_request["request_size"])
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
         self.assertEqual(set(http_request.keys()), set(_HTTP_REQUEST_FIELDS))
-
 
 
 class Test_get_request_data(unittest.TestCase):

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -94,7 +94,7 @@ class TestAppEngineHandler(unittest.TestCase):
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
             return_value=({"request_url": "test"}, "trace-test"),
         )
-        with get_request_patch as mock_get_request:
+        with get_request_patch:
 
             client = mock.Mock(project=self.PROJECT, spec=["project"])
             handler = self._make_one(client, transport=_Transport)

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -89,7 +89,7 @@ class TestAppEngineHandler(unittest.TestCase):
     def test_emit(self):
         expected_http_request = {"request_url": "test"}
         trace_id = "trace-test"
-        expected_trace_id = f"projects/{self.PROJECT}/{trace_id}"
+        expected_trace_id = f"projects/{self.PROJECT}/traces/{trace_id}"
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
             return_value=({"request_url": "test"}, "trace-test"),

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -87,36 +87,45 @@ class TestAppEngineHandler(unittest.TestCase):
         self.assertIs(handler.stream, stream)
 
     def test_emit(self):
-        client = mock.Mock(project=self.PROJECT, spec=["project"])
-        handler = self._make_one(client, transport=_Transport)
-        gae_resource = handler.get_gae_resource()
-        gae_labels = handler.get_gae_labels()
-        trace = None
-        logname = "app"
-        message = "hello world"
-        record = logging.LogRecord(logname, logging, None, None, message, None, None)
-        handler.emit(record)
-
-        self.assertIs(handler.transport.client, client)
-        self.assertEqual(handler.transport.name, logname)
-        self.assertEqual(
-            handler.transport.send_called_with,
-            (record, message, gae_resource, gae_labels, trace),
+        expected_http_request = {'request_url':'test'}
+        trace_id = 'trace-test'
+        expected_trace_id = f'projects/{self.PROJECT}/{trace_id}'
+        get_request_patch = mock.patch(
+            "google.cloud.logging_v2.handlers.app_engine.get_request_data",
+            return_value=({'request_url':'test'}, 'trace-test'),
         )
+        with get_request_patch as mock_get_request:
+
+            client = mock.Mock(project=self.PROJECT, spec=["project"])
+            handler = self._make_one(client, transport=_Transport)
+            gae_resource = handler.get_gae_resource()
+            gae_labels = handler.get_gae_labels()
+            logname = "app"
+            message = "hello world"
+            record = logging.LogRecord(logname, logging, None, None, message, None, None)
+            handler.project_id = self.PROJECT
+            handler.emit(record)
+
+            self.assertIs(handler.transport.client, client)
+            self.assertEqual(handler.transport.name, logname)
+            self.assertEqual(
+                handler.transport.send_called_with,
+                (record, message, gae_resource, gae_labels, expected_trace_id, expected_http_request)
+            )
 
     def _get_gae_labels_helper(self, trace_id):
-        get_trace_patch = mock.patch(
-            "google.cloud.logging_v2.handlers.app_engine.get_trace_id",
-            return_value=trace_id,
+        get_request_patch = mock.patch(
+            "google.cloud.logging_v2.handlers.app_engine.get_request_data",
+            return_value=(None, trace_id),
         )
 
         client = mock.Mock(project=self.PROJECT, spec=["project"])
         # The handler actually calls ``get_gae_labels()``.
-        with get_trace_patch as mock_get_trace:
+        with get_request_patch as mock_get_request:
             handler = self._make_one(client, transport=_Transport)
 
             gae_labels = handler.get_gae_labels()
-            self.assertEqual(mock_get_trace.mock_calls, [mock.call()])
+            self.assertEqual(mock_get_request.mock_calls, [mock.call()])
 
         return gae_labels
 
@@ -138,5 +147,5 @@ class _Transport(object):
         self.client = client
         self.name = name
 
-    def send(self, record, message, resource, labels, trace):
-        self.send_called_with = (record, message, resource, labels, trace)
+    def send(self, record, message, resource, labels, trace, http_request):
+        self.send_called_with = (record, message, resource, labels, trace, http_request)

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -87,12 +87,12 @@ class TestAppEngineHandler(unittest.TestCase):
         self.assertIs(handler.stream, stream)
 
     def test_emit(self):
-        expected_http_request = {'request_url':'test'}
-        trace_id = 'trace-test'
-        expected_trace_id = f'projects/{self.PROJECT}/{trace_id}'
+        expected_http_request = {"request_url": "test"}
+        trace_id = "trace-test"
+        expected_trace_id = f"projects/{self.PROJECT}/{trace_id}"
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
-            return_value=({'request_url':'test'}, 'trace-test'),
+            return_value=({"request_url": "test"}, "trace-test"),
         )
         with get_request_patch as mock_get_request:
 
@@ -102,7 +102,9 @@ class TestAppEngineHandler(unittest.TestCase):
             gae_labels = handler.get_gae_labels()
             logname = "app"
             message = "hello world"
-            record = logging.LogRecord(logname, logging, None, None, message, None, None)
+            record = logging.LogRecord(
+                logname, logging, None, None, message, None, None
+            )
             handler.project_id = self.PROJECT
             handler.emit(record)
 
@@ -110,7 +112,14 @@ class TestAppEngineHandler(unittest.TestCase):
             self.assertEqual(handler.transport.name, logname)
             self.assertEqual(
                 handler.transport.send_called_with,
-                (record, message, gae_resource, gae_labels, expected_trace_id, expected_http_request)
+                (
+                    record,
+                    message,
+                    gae_resource,
+                    gae_labels,
+                    expected_trace_id,
+                    expected_http_request,
+                ),
             )
 
     def _get_gae_labels_helper(self, trace_id):

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -92,10 +92,10 @@ class TestAppEngineHandler(unittest.TestCase):
         expected_trace_id = f"projects/{self.PROJECT}/traces/{trace_id}"
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
-            return_value=({"request_url": "test"}, "trace-test"),
+            return_value=(expected_http_request, trace_id),
         )
         with get_request_patch:
-
+            # library integrations mocked to return test data
             client = mock.Mock(project=self.PROJECT, spec=["project"])
             handler = self._make_one(client, transport=_Transport)
             gae_resource = handler.get_gae_resource()

--- a/tests/unit/handlers/transports/test_background_thread.py
+++ b/tests/unit/handlers/transports/test_background_thread.py
@@ -64,9 +64,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, resource=_GLOBAL_RESOURCE)
 
         transport.worker.enqueue.assert_called_once_with(
-            record,
-            message,
-            resource=_GLOBAL_RESOURCE,
+            record, message, resource=_GLOBAL_RESOURCE,
         )
 
     def test_trace_send(self):
@@ -88,10 +86,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, resource=_GLOBAL_RESOURCE, trace=trace)
 
         transport.worker.enqueue.assert_called_once_with(
-            record,
-            message,
-            resource=_GLOBAL_RESOURCE,
-            trace=trace,
+            record, message, resource=_GLOBAL_RESOURCE, trace=trace,
         )
 
     def test_span_send(self):
@@ -113,10 +108,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
         transport.send(record, message, resource=_GLOBAL_RESOURCE, span_id=span_id)
 
         transport.worker.enqueue.assert_called_once_with(
-            record,
-            message,
-            resource=_GLOBAL_RESOURCE,
-            span_id=span_id,
+            record, message, resource=_GLOBAL_RESOURCE, span_id=span_id,
         )
 
     def test_flush(self):

--- a/tests/unit/handlers/transports/test_background_thread.py
+++ b/tests/unit/handlers/transports/test_background_thread.py
@@ -70,7 +70,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=None,
             span_id=None,
-            http_request=None
+            http_request=None,
         )
 
     def test_trace_send(self):
@@ -98,7 +98,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=trace,
             span_id=None,
-            http_request=None
+            http_request=None,
         )
 
     def test_span_send(self):
@@ -126,7 +126,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=None,
             span_id=span_id,
-            http_request=None
+            http_request=None,
         )
 
     def test_flush(self):

--- a/tests/unit/handlers/transports/test_background_thread.py
+++ b/tests/unit/handlers/transports/test_background_thread.py
@@ -70,6 +70,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=None,
             span_id=None,
+            http_request=None
         )
 
     def test_trace_send(self):
@@ -97,6 +98,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=trace,
             span_id=None,
+            http_request=None
         )
 
     def test_span_send(self):
@@ -124,6 +126,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             labels=None,
             trace=None,
             span_id=span_id,
+            http_request=None
         )
 
     def test_flush(self):
@@ -301,6 +304,7 @@ class Test_Worker(unittest.TestCase):
         self.assertIsNone(entry["labels"])
         self.assertIsNone(entry["trace"])
         self.assertIsNone(entry["span_id"])
+        self.assertIsNone(entry["http_request"])
         self.assertIsInstance(entry["timestamp"], datetime.datetime)
 
     def test_enqueue_explicit(self):
@@ -503,6 +507,7 @@ class _Batch(object):
         trace=None,
         span_id=None,
         timestamp=None,
+        http_request=None,
     ):
         from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 

--- a/tests/unit/handlers/transports/test_background_thread.py
+++ b/tests/unit/handlers/transports/test_background_thread.py
@@ -67,10 +67,6 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             record,
             message,
             resource=_GLOBAL_RESOURCE,
-            labels=None,
-            trace=None,
-            span_id=None,
-            http_request=None,
         )
 
     def test_trace_send(self):
@@ -95,10 +91,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             record,
             message,
             resource=_GLOBAL_RESOURCE,
-            labels=None,
             trace=trace,
-            span_id=None,
-            http_request=None,
         )
 
     def test_span_send(self):
@@ -123,10 +116,7 @@ class TestBackgroundThreadHandler(unittest.TestCase):
             record,
             message,
             resource=_GLOBAL_RESOURCE,
-            labels=None,
-            trace=None,
             span_id=span_id,
-            http_request=None,
         )
 
     def test_flush(self):
@@ -300,12 +290,12 @@ class Test_Worker(unittest.TestCase):
         expected_info = {"message": message, "python_logger": "testing"}
         self.assertEqual(entry["info"], expected_info)
         self.assertEqual(entry["severity"], LogSeverity.INFO)
-        self.assertIsNone(entry["resource"])
-        self.assertIsNone(entry["labels"])
-        self.assertIsNone(entry["trace"])
-        self.assertIsNone(entry["span_id"])
-        self.assertIsNone(entry["http_request"])
         self.assertIsInstance(entry["timestamp"], datetime.datetime)
+        self.assertNotIn("resource", entry.keys())
+        self.assertNotIn("labels", entry.keys())
+        self.assertNotIn("trace", entry.keys())
+        self.assertNotIn("span_id", entry.keys())
+        self.assertNotIn("http_request", entry.keys())
 
     def test_enqueue_explicit(self):
         import datetime

--- a/tests/unit/handlers/transports/test_sync.py
+++ b/tests/unit/handlers/transports/test_sync.py
@@ -58,6 +58,7 @@ class TestSyncHandler(unittest.TestCase):
             None,
             None,
             None,
+            None,
         )
         self.assertEqual(transport.logger.log_struct_called_with, EXPECTED_SENT)
 
@@ -76,6 +77,7 @@ class _Logger(object):
         labels=None,
         trace=None,
         span_id=None,
+        http_request=None,
     ):
         self.log_struct_called_with = (
             message,
@@ -84,6 +86,7 @@ class _Logger(object):
             labels,
             trace,
             span_id,
+            http_request,
         )
 
 


### PR DESCRIPTION
This PR adds support for the [`http_request`](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) field that's part of the Cloud Logging LogEntry spec. Details about the request (method, url, payload size, user agent, remote ip, referrer) will be attached as metadata to each log when possible. These fields will be inferred from Flask and Django environments, just as the `trace_id` currently is. 

I plan to allow users to set this information manually as well for users using unsupported libraries, but that will come in a separate PR

Currently only fully supported on AppEngine

This fixes https://github.com/googleapis/python-logging/issues/72, partially addresses https://github.com/googleapis/python-logging/issues/110, and lays some groundwork for later improvements