### PR TITLE
fix: add InternalServerError to list of expected errors

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -20,6 +20,7 @@ import unittest
 
 from google.api_core.exceptions import BadGateway
 from google.api_core.exceptions import Conflict
+from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import TooManyRequests
 from google.api_core.exceptions import ResourceExhausted
@@ -67,7 +68,7 @@ def _list_entries(logger):
     :returns: List of all entries consumed.
     """
     inner = RetryResult(_has_entries, max_tries=9)(_consume_entries)
-    outer = RetryErrors((ServiceUnavailable, ResourceExhausted), max_tries=9)(inner)
+    outer = RetryErrors((ServiceUnavailable, ResourceExhausted, InternalServerError), max_tries=9)(inner)
     return outer(logger)
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -68,7 +68,9 @@ def _list_entries(logger):
     :returns: List of all entries consumed.
     """
     inner = RetryResult(_has_entries, max_tries=9)(_consume_entries)
-    outer = RetryErrors((ServiceUnavailable, ResourceExhausted, InternalServerError), max_tries=9)(inner)
+    outer = RetryErrors(
+        (ServiceUnavailable, ResourceExhausted, InternalServerError), max_tries=9
+    )(inner)
     return outer(logger)
 
 


### PR DESCRIPTION
We are currently seeing a failure on the continuous CI tests for this repo. It looks like an internal server error is showing up on one of the list_logs calls. This fix adds that exception to the list of exceptions to retry