### PR TITLE
fix: use dict for http request

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -23,7 +23,6 @@ except ImportError:  # pragma: NO COVER
     flask = None
 
 from google.cloud.logging_v2.handlers.middleware.request import _get_django_request
-from google.logging.type.http_request_pb2 import HttpRequest
 
 _DJANGO_TRACE_HEADER = "HTTP_X_CLOUD_TRACE_CONTEXT"
 _DJANGO_USERAGENT_HEADER = "HTTP_USER_AGENT"
@@ -55,7 +54,7 @@ def get_request_data_from_flask():
     """Get http_request and trace data from flask request headers.
 
     Returns:
-        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+        Tuple[Optional[dict], Optional[str]]:
             Data related to the current http request and the trace_id for the
             request. Both fields will be None if a flask request isn't found.
     """
@@ -63,15 +62,15 @@ def get_request_data_from_flask():
         return None, None
 
     # build http_request
-    http_request = HttpRequest(
-        request_method=flask.request.method,
-        request_url=flask.request.url,
-        request_size=flask.request.content_length,
-        user_agent=flask.request.user_agent.string,
-        remote_ip=flask.request.remote_addr,
-        referer=flask.request.referrer,
-        protocol=flask.request.environ.get(_PROTOCOL_HEADER),
-    )
+    http_request = {
+        "request_method": flask.request.method,
+        "request_url": flask.request.url,
+        "request_size": flask.request.content_length,
+        "user_agent":flask.request.user_agent.string,
+        "remote_ip": flask.request.remote_addr,
+        "referer": flask.request.referrer,
+        "protocol": flask.request.environ.get(_PROTOCOL_HEADER),
+    }
 
     # find trace id
     trace_id = None
@@ -86,7 +85,7 @@ def get_request_data_from_django():
     """Get http_request and trace data from django request headers.
 
     Returns:
-        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+        Tuple[Optional[dict], Optional[str]]:
             Data related to the current http request and the trace_id for the
             request. Both fields will be None if a django request isn't found.
     """
@@ -95,15 +94,15 @@ def get_request_data_from_django():
     if request is None:
         return None, None
     # build http_request
-    http_request = HttpRequest(
-        request_method=request.method,
-        request_url=request.build_absolute_uri(),
-        request_size=len(request.body),
-        user_agent=request.META.get(_DJANGO_USERAGENT_HEADER),
-        remote_ip=request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
-        referer=request.META.get(_DJANGO_REFERER_HEADER),
-        protocol=request.META.get(_PROTOCOL_HEADER),
-    )
+    http_request = {
+        "request_method": request.method,
+        "request_url": request.build_absolute_uri(),
+        "request_size": len(request.body),
+        "user_agent": request.META.get(_DJANGO_USERAGENT_HEADER),
+        "remote_ip": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
+        "referer": request.META.get(_DJANGO_REFERER_HEADER),
+        "protocol": request.META.get(_PROTOCOL_HEADER),
+    }
 
     # find trace id
     trace_id = None
@@ -119,7 +118,7 @@ def get_request_data():
     frameworks (currently supported: Flask and Django).
 
     Returns:
-        Tuple[Optional[google.logging.type.http_request_pb2.HttpRequest], Optional[str]]:
+        Tuple[Optional[dict], Optional[str]]:
             Data related to the current http request and the trace_id for the
             request. Both fields will be None if a supported web request isn't found.
     """

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -66,7 +66,7 @@ def get_request_data_from_flask():
         "request_method": flask.request.method,
         "request_url": flask.request.url,
         "request_size": flask.request.content_length,
-        "user_agent":flask.request.user_agent.string,
+        "user_agent": flask.request.user_agent.string,
         "remote_ip": flask.request.remote_addr,
         "referer": flask.request.referrer,
         "protocol": flask.request.environ.get(_PROTOCOL_HEADER),

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -63,11 +63,11 @@ def get_request_data_from_flask():
 
     # build http_request
     http_request = {
-        "request_method": flask.request.method,
-        "request_url": flask.request.url,
-        "request_size": flask.request.content_length,
-        "user_agent": flask.request.user_agent.string,
-        "remote_ip": flask.request.remote_addr,
+        "requestMethod": flask.request.method,
+        "requestUrl": flask.request.url,
+        "requestSize": flask.request.content_length,
+        "userAgent": flask.request.user_agent.string,
+        "remoteIp": flask.request.remote_addr,
         "referer": flask.request.referrer,
         "protocol": flask.request.environ.get(_PROTOCOL_HEADER),
     }
@@ -95,11 +95,11 @@ def get_request_data_from_django():
         return None, None
     # build http_request
     http_request = {
-        "request_method": request.method,
-        "request_url": request.build_absolute_uri(),
-        "request_size": len(request.body),
-        "user_agent": request.META.get(_DJANGO_USERAGENT_HEADER),
-        "remote_ip": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
+        "requestMethod": request.method,
+        "requestUrl": request.build_absolute_uri(),
+        "requestSize": len(request.body),
+        "userAgent": request.META.get(_DJANGO_USERAGENT_HEADER),
+        "remoteIp": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
         "referer": request.META.get(_DJANGO_REFERER_HEADER),
         "protocol": request.META.get(_PROTOCOL_HEADER),
     }

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -47,7 +47,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertIsNone(trace_id)
-        self.assertEqual(http_request.request_method, "GET")
+        self.assertEqual(http_request["request_method"], "GET")
 
     def test_valid_context_header(self):
         flask_trace_header = "X_CLOUD_TRACE_CONTEXT"
@@ -63,7 +63,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request.request_method, "GET")
+        self.assertEqual(http_request["request_method"], "GET")
 
     def test_http_request_populated(self):
         expected_path = "http://testserver/123"
@@ -86,13 +86,13 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             )
             http_request, trace_id = self._call_fut()
 
-        self.assertEqual(http_request.request_method, "PUT")
-        self.assertEqual(http_request.request_url, expected_path)
-        self.assertEqual(http_request.user_agent, expected_agent)
-        self.assertEqual(http_request.referer, expected_referrer)
-        self.assertEqual(http_request.remote_ip, expected_ip)
-        self.assertEqual(http_request.request_size, len(body_content))
-        self.assertEqual(http_request.protocol, "HTTP/1.1")
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["referer"], expected_referrer)
+        self.assertEqual(http_request["remote_ip"], expected_ip)
+        self.assertEqual(http_request["request_size"], len(body_content))
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
         expected_path = "http://testserver/123"
@@ -100,9 +100,9 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         with app.test_client() as c:
             c.put(path=expected_path)
             http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request.request_method, "PUT")
-        self.assertEqual(http_request.request_url, expected_path)
-        self.assertEqual(http_request.protocol, "HTTP/1.1")
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 
 class Test_get_request_data_from_django(unittest.TestCase):
@@ -136,7 +136,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request.request_method, "GET")
+        self.assertEqual(http_request["request_method"], "GET")
         self.assertIsNone(trace_id)
 
     def test_valid_context_header(self):
@@ -156,7 +156,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request.request_method, "GET")
+        self.assertEqual(http_request["request_method"], "GET")
 
     def test_http_request_populated(self):
         from django.test import RequestFactory
@@ -176,13 +176,13 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request.request_method, "PUT")
-        self.assertEqual(http_request.request_url, expected_path)
-        self.assertEqual(http_request.user_agent, expected_agent)
-        self.assertEqual(http_request.referer, expected_referrer)
-        self.assertEqual(http_request.remote_ip, "127.0.0.1")
-        self.assertEqual(http_request.request_size, len(body_content))
-        self.assertEqual(http_request.protocol, "HTTP/1.1")
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["referer"], expected_referrer)
+        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
+        self.assertEqual(http_request["request_size"], len(body_content))
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
         from django.test import RequestFactory
@@ -193,10 +193,10 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request.request_method, "PUT")
-        self.assertEqual(http_request.request_url, expected_path)
-        self.assertEqual(http_request.remote_ip, "127.0.0.1")
-        self.assertEqual(http_request.protocol, "HTTP/1.1")
+        self.assertEqual(http_request["request_method"], "PUT")
+        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 
 class Test_get_request_data(unittest.TestCase):

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -17,9 +17,9 @@ import unittest
 import mock
 
 _FLASK_TRACE_ID = "flask-id"
-_FLASK_HTTP_REQUEST = {"request_url": "https://flask.palletsprojects.com/en/1.1.x/"}
+_FLASK_HTTP_REQUEST = {"requestUrl": "https://flask.palletsprojects.com/en/1.1.x/"}
 _DJANGO_TRACE_ID = "django-id"
-_DJANGO_HTTP_REQUEST = {"request_url": "https://www.djangoproject.com/"}
+_DJANGO_HTTP_REQUEST = {"requestUrl": "https://www.djangoproject.com/"}
 
 
 class Test_get_request_data_from_flask(unittest.TestCase):
@@ -47,7 +47,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertIsNone(trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
+        self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_valid_context_header(self):
         flask_trace_header = "X_CLOUD_TRACE_CONTEXT"
@@ -63,7 +63,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
+        self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_http_request_populated(self):
         expected_path = "http://testserver/123"
@@ -86,12 +86,12 @@ class Test_get_request_data_from_flask(unittest.TestCase):
             )
             http_request, trace_id = self._call_fut()
 
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestUrl"], expected_path)
+        self.assertEqual(http_request["userAgent"], expected_agent)
         self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remote_ip"], expected_ip)
-        self.assertEqual(http_request["request_size"], len(body_content))
+        self.assertEqual(http_request["remoteIp"], expected_ip)
+        self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -100,8 +100,8 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         with app.test_client() as c:
             c.put(path=expected_path)
             http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
+        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 
@@ -136,7 +136,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "GET")
+        self.assertEqual(http_request["requestMethod"], "GET")
         self.assertIsNone(trace_id)
 
     def test_valid_context_header(self):
@@ -156,7 +156,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, trace_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
-        self.assertEqual(http_request["request_method"], "GET")
+        self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_http_request_populated(self):
         from django.test import RequestFactory
@@ -176,12 +176,12 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["user_agent"], expected_agent)
+        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestUrl"], expected_path)
+        self.assertEqual(http_request["userAgent"], expected_agent)
         self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
-        self.assertEqual(http_request["request_size"], len(body_content))
+        self.assertEqual(http_request["remoteIp"], "127.0.0.1")
+        self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -193,9 +193,9 @@ class Test_get_request_data_from_django(unittest.TestCase):
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
         http_request, trace_id = self._call_fut()
-        self.assertEqual(http_request["request_method"], "PUT")
-        self.assertEqual(http_request["request_url"], expected_path)
-        self.assertEqual(http_request["remote_ip"], "127.0.0.1")
+        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestUrl"], expected_path)
+        self.assertEqual(http_request["remoteIp"], "127.0.0.1")
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 


### PR DESCRIPTION
It was recently reported that the new http request inference is throwing exceptions on at least AppEngine. This PR changes the http_request object to use a standard dict instead of the HttpRequest type, as that seems to be expected by some of the parsers involved.

More tests in this area are needed going forward.

Fixes https://github.com/googleapis/python-logging/issues/155
