### PR TITLE
fix: django content length extraction bug

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: NO COVER
 
 from google.cloud.logging_v2.handlers.middleware.request import _get_django_request
 
+_DJANGO_CONTENT_LENGTH = "CONTENT_LENGTH"
 _DJANGO_TRACE_HEADER = "HTTP_X_CLOUD_TRACE_CONTEXT"
 _DJANGO_USERAGENT_HEADER = "HTTP_USER_AGENT"
 _DJANGO_REMOTE_ADDR_HEADER = "REMOTE_ADDR"
@@ -93,11 +94,18 @@ def get_request_data_from_django():
 
     if request is None:
         return None, None
+
+    # convert content_length to int if it exists
+    content_length = None
+    try:
+        content_length = int(request.META.get(_DJANGO_CONTENT_LENGTH))
+    except (ValueError, TypeError):
+        content_length = None
     # build http_request
     http_request = {
         "requestMethod": request.method,
         "requestUrl": request.build_absolute_uri(),
-        "requestSize": len(request.body),
+        "requestSize": content_length,
         "userAgent": request.META.get(_DJANGO_USERAGENT_HEADER),
         "remoteIp": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
         "referer": request.META.get(_DJANGO_REFERER_HEADER),

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -172,6 +172,9 @@ class Test_get_request_data_from_django(unittest.TestCase):
             HTTP_USER_AGENT=expected_agent,
             HTTP_REFERER=expected_referrer,
         )
+        # ensure test passes even after request has been read
+        # context: https://github.com/googleapis/python-logging/issues/159
+        django_request.read()
 
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)


### PR DESCRIPTION
We recently added a feature to extract http_request data from Flask and Django environments. Django had a bug where multiple
logs originating from the same request would throw an exception, due to Django no allowing `request.body` access after an IO operation.

I updated the http_request content length code to use `request.META` instead of `request.body`, to match the other fields. I also added a test to make sure this django behaviour doesn't cause issues in the future

Fixes https://github.com/googleapis/python-logging/issues/159 🦕
