### PR TITLE
test: reduced time filter length in system tests

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -67,15 +67,13 @@ def _list_entries(logger, max_tries=5):
                 raise RuntimeError('no results found')
             else:
                 return entries
-        except (ServiceUnavailable, ResourceExhausted, InternalServerError,
-                RuntimeError) as e:
-            print(f'Error: {e}')
+        except:
             time.sleep(delay)
             try_num += 1
             delay *= 2
             if try_num >= max_tries:
                 # finished retries. Raise error again
-                raise e
+                raise
     return None
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -60,9 +60,11 @@ def _list_entries(logger, max_tries=5):
     delay = 1
     try_num = 0
     latest_error = None
+    10_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
+    time_filter = f'timestamp>="{10_mins_ago.strftime(_TIME_FORMAT)}"'
     while try_num < max_tries:
         try:
-            entries = list(logger.list_entries())
+            entries = list(logger.list_entries(filter_=time_filter))
             if not entries:
                 raise RuntimeError('no results found')
             else:

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -68,10 +68,10 @@ def _list_entries(logger):
     :rtype: list
     :returns: List of all entries consumed.
     """
-    inner = RetryResult(_has_entries, max_tries=9, delay=1, backoff=2)(_consume_entries)
+    inner = RetryResult(_has_entries, max_tries=6, delay=1, backoff=2)(_consume_entries)
     outer = RetryErrors(
-        (ServiceUnavailable, ResourceExhausted, InternalServerError), max_tries=9
-    )(inner)
+        (ServiceUnavailable, ResourceExhausted, InternalServerError),
+        max_tries=6, delay=1, backoff=2)(inner)
     return outer(logger)
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -68,7 +68,7 @@ def _list_entries(logger):
     :rtype: list
     :returns: List of all entries consumed.
     """
-    inner = RetryResult(_has_entries, max_tries=9)(_consume_entries)
+    inner = RetryResult(_has_entries, max_tries=9, delay=1, backoff=2)(_consume_entries)
     outer = RetryErrors(
         (ServiceUnavailable, ResourceExhausted, InternalServerError), max_tries=9
     )(inner)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 import logging
 import os
 import pytest
@@ -176,11 +178,9 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
 
     def test_log_text_with_timestamp(self):
-        import datetime
-
         text_payload = "System test: test_log_text_with_timestamp"
         logger = Config.CLIENT.logger(self._logger_name("log_text_ts"))
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
 
         self.to_delete.append(logger)
 
@@ -189,13 +189,13 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].payload, text_payload)
         self.assertEqual(entries[0].timestamp, now.replace(tzinfo=UTC))
-        self.assertIsInstance(entries[0].received_timestamp, datetime.datetime)
+        self.assertIsInstance(entries[0].received_timestamp, datetime)
 
     def test_log_text_with_resource(self):
         text_payload = "System test: test_log_text_with_timestamp"
 
         logger = Config.CLIENT.logger(self._logger_name("log_text_res"))
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
         resource = Resource(
             type="gae_app",
             labels={"module_id": "default", "version_id": "test", "zone": ""},

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -49,6 +49,7 @@ retry_429 = RetryErrors(TooManyRequests)
 _ten_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
 _time_filter = f'timestamp>="{_ten_mins_ago.strftime(_TIME_FORMAT)}"'
 
+
 def _consume_entries(logger):
     """Consume all recent log entries from logger iterator.
     :type logger: :class:`~google.cloud.logging.logger.Logger`
@@ -71,12 +72,12 @@ def _list_entries(logger):
     :rtype: list
     :returns: List of all entries consumed.
     """
-    inner = RetryResult(
-        _has_entries, delay=1, backoff=2, max_tries=6
-    )(_consume_entries)
+    inner = RetryResult(_has_entries, delay=1, backoff=2, max_tries=6)(_consume_entries)
     outer = RetryErrors(
         (ServiceUnavailable, ResourceExhausted, InternalServerError),
-        delay=1, backoff=2, max_tries=6
+        delay=1,
+        backoff=2,
+        max_tries=6,
     )(inner)
     return outer(logger)
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -60,8 +60,8 @@ def _list_entries(logger, max_tries=5):
     delay = 1
     try_num = 0
     latest_error = None
-    10_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
-    time_filter = f'timestamp>="{10_mins_ago.strftime(_TIME_FORMAT)}"'
+    ten_mins_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
+    time_filter = f'timestamp>="{ten_mins_ago.strftime(_TIME_FORMAT)}"'
     while try_num < max_tries:
         try:
             entries = list(logger.list_entries(filter_=time_filter))


### PR DESCRIPTION
CI system tests have been failing for a week now. It looks like a rogue service has been flooding the test project with logs, which made our tests timeout

We fixed the problem on the project side, but I'm also introducing a change here to only query the last 10 minutes of logs. This should avoid similar problems from breaking our tests in the future
