### PR TITLE
tests: update environment test script path

### DIFF
--- a/.kokoro/environment/appengine_flex_container/common.cfg
+++ b/.kokoro/environment/appengine_flex_container/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_flex_container/common.cfg
+++ b/.kokoro/environment/appengine_flex_container/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_flex_python/common.cfg
+++ b/.kokoro/environment/appengine_flex_python/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_flex_python/common.cfg
+++ b/.kokoro/environment/appengine_flex_python/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_flex_python/common.cfg
+++ b/.kokoro/environment/appengine_flex_python/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_standard/common.cfg
+++ b/.kokoro/environment/appengine_standard/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_standard/common.cfg
+++ b/.kokoro/environment/appengine_standard/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/appengine_standard/common.cfg
+++ b/.kokoro/environment/appengine_standard/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/cloudrun/common.cfg
+++ b/.kokoro/environment/cloudrun/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/cloudrun/common.cfg
+++ b/.kokoro/environment/cloudrun/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/cloudrun/common.cfg
+++ b/.kokoro/environment/cloudrun/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/compute/common.cfg
+++ b/.kokoro/environment/compute/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/compute/common.cfg
+++ b/.kokoro/environment/compute/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/compute/common.cfg
+++ b/.kokoro/environment/compute/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/functions/common.cfg
+++ b/.kokoro/environment/functions/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/functions/common.cfg
+++ b/.kokoro/environment/functions/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/functions/common.cfg
+++ b/.kokoro/environment/functions/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/kubernetes/common.cfg
+++ b/.kokoro/environment/kubernetes/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging.kokoro/environment_tests.sh"
+    value: "github/python-logging/kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/kubernetes/common.cfg
+++ b/.kokoro/environment/kubernetes/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "python-logging/.kokoro/environment_tests.sh"
+    value: "github/python-logging.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment/kubernetes/common.cfg
+++ b/.kokoro/environment/kubernetes/common.cfg
@@ -30,5 +30,5 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-logging/kokoro/environment_tests.sh"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
 }

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -20,10 +20,14 @@ if [[ -z "${ENVIRONMENT:-}" ]]; then
   exit 1
 fi
 
+if [[ -z "${PROJECT_ROOT:-}"  ]]; then
+    PROJECT_ROOT="github/python-logging"
+fi
+
 # make sure submodule is up to date
 git submodule update --init --recursive
 
-cd python-logging/tests/environment
+cd "${PROJECT_ROOT}/tests/environment"
 
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -20,6 +20,9 @@ if [[ -z "${ENVIRONMENT:-}" ]]; then
   exit 1
 fi
 
+# make sure submodule is up to date
+git submodule update --init --recursive
+
 cd python-logging/tests/environment
 
 # Disable buffering, so that the logs stream through.


### PR DESCRIPTION
The first kokoro run for the appengine standard environment test failed, saying it couldn't find the environment_tests.sh script. I updated the path to prefix with github, as that's the pattern I see in the samples tests. We'll see if that fixes the issue
