### PR TITLE
tests: clean up properly after completion

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -65,7 +65,7 @@ TEST_STATUS_CODE=$?
 
 # destroy resources
 echo "cleaning up..."
-/workspace/python-logging/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
 
 # exit with proper status code
 exit $TEST_STATUS_CODE


### PR DESCRIPTION
The recent environment test run displayed an error when it attempted to clean up the environment at the end. This should fix the path for the command
