### PR TITLE
tests: fix environment test issues

### DIFF
--- a/.kokoro/environment/kubernetes/common.cfg
+++ b/.kokoro/environment/kubernetes/common.cfg
@@ -11,7 +11,7 @@ action {
 # Specify which tests to run
 env_vars: {
     key: "ENVIRONMENT"
-    value: "kubernetesengine"
+    value: "kubernetes"
 }
 
 # Download trampoline resources.

--- a/.kokoro/environment/kubernetes/common.cfg
+++ b/.kokoro/environment/kubernetes/common.cfg
@@ -11,7 +11,7 @@ action {
 # Specify which tests to run
 env_vars: {
     key: "ENVIRONMENT"
-    value: "kubernetes"
+    value: "kubernetesengine"
 }
 
 # Download trampoline resources.

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -61,6 +61,14 @@ UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
 export ENVCTL_ID=ci-$UUID
 echo $ENVCTL_ID
 
+
+# testing the commands
+set +e
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+
 # Run the specified environment test
 set +e
 python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -72,12 +72,6 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
-
-
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
-
 python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -71,6 +71,12 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
+
+
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+
 python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -59,8 +59,9 @@ python3.6 -m nox --version
 # Install kubectl
 if [[ "${ENVIRONMENT}" == "kubernetes" ]]; then
   curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
-  mkdir -p ~/.local/bin/kubectl
-  mv ./kubectl ~/.local/bin/kubectl
+  chmod +x kubectl
+  mkdir -p ~/.local/bin
+  mv ./kubectl ~/.local/bin
   export PATH=$PATH:~/.local/bin
 fi
 

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -57,7 +57,7 @@ python3.6 -m pip install --upgrade --quiet nox
 python3.6 -m nox --version
 
 # Install kubectl
-gcloud components install kubectl
+sudo apt-get install kubectl
 
 # create a unique id for this run
 UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -57,23 +57,17 @@ python3.6 -m pip install --upgrade --quiet nox
 python3.6 -m nox --version
 
 # Install kubectl
-curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
-mkdir -p ~/.local/bin/kubectl
-mv ./kubectl ~/.local/bin/kubectl
-export PATH=$PATH:~/.local/bin
+if [[ "${ENVIRONMENT}" == "kubernetes" ]]; then
+  curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
+  mkdir -p ~/.local/bin/kubectl
+  mv ./kubectl ~/.local/bin/kubectl
+  export PATH=$PATH:~/.local/bin
+fi
 
 # create a unique id for this run
 UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
 export ENVCTL_ID=ci-$UUID
 echo $ENVCTL_ID
-
-
-# testing the commands
-set +e
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT verify
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
 
 # Run the specified environment test
 set +e

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -56,6 +56,9 @@ python3.6 -m pip uninstall --yes --quiet nox-automation
 python3.6 -m pip install --upgrade --quiet nox
 python3.6 -m nox --version
 
+# Install kubectl
+gcloud components install kubectl
+
 # create a unique id for this run
 UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
 export ENVCTL_ID=ci-$UUID

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -57,7 +57,10 @@ python3.6 -m pip install --upgrade --quiet nox
 python3.6 -m nox --version
 
 # Install kubectl
-sudo apt-get install kubectl
+curl -LO https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl
+mkdir -p ~/.local/bin/kubectl
+mv ./kubectl ~/.local/bin/kubectl
+export PATH=$PATH:~/.local/bin
 
 # create a unique id for this run
 UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -43,6 +43,9 @@ gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 export PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/project-id.json")
 gcloud config set project $PROJECT_ID
 
+# set a default zone.
+gcloud config set compute/zone us-central1-b
+
 # authenticate docker
 gcloud auth configure-docker -q
 


### PR DESCRIPTION
I enabled environment tests for all other GCP environments. This PR fixes some minor bugs that were breaking some of the runs.

I'm still seeing GKE and GCE being flaky, but those fixes might have to be addressed in a different PR