### PR TITLE
tests: fix failing kubernetes test

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -72,19 +72,12 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
-
-${PROJECT_ROOT}/tests/environment/envctl/envctl python  $ENVIRONMENT deploy
-kubectl get pods
-kubectl describe pod
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
-
-
-#python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
+python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources
-#echo "cleaning up..."
-#${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+echo "cleaning up..."
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
 
 # exit with proper status code
 exit $TEST_STATUS_CODE

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -75,6 +75,7 @@ set +e
 
 ${PROJECT_ROOT}/tests/environment/envctl/envctl python  $ENVIRONMENT deploy
 kubectl get pods
+kubectl describe pod
 ${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
 
 

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -72,12 +72,18 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
-python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
+
+${PROJECT_ROOT}/tests/environment/envctl/envctl python  $ENVIRONMENT deploy
+kubectl get pods
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+
+
+#python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources
-echo "cleaning up..."
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
+#echo "cleaning up..."
+#${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT destroy
 
 # exit with proper status code
 exit $TEST_STATUS_CODE


### PR DESCRIPTION
This PR pulls in some changes from the environment test submodule. 
- Main fix: fixes the currently broken GKE test (by fixing the scopes)
- changes the functions environment to python38
- adds some more functions to the deployable bundle