### PR TITLE
test: add functions_37 environment test config

### DIFF
--- a/.kokoro/environment/functions_37/common.cfg
+++ b/.kokoro/environment/functions_37/common.cfg
@@ -1,0 +1,39 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+
+# Specify which tests to run
+env_vars: {
+    key: "ENVIRONMENT"
+    value: "functions"
+}
+
+env_vars: {
+    key: "RUNTIME"
+    value: "python37"
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Download resources for system tests (service account key, etc.)
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-python"
+
+# Use the trampoline script to run in docker.
+build_file: "python-logging/.kokoro/trampoline_v2.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/python-multi"
+}
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/python-logging/.kokoro/environment_tests.sh"
+}

--- a/.kokoro/environment/functions_37/continuous.cfg
+++ b/.kokoro/environment/functions_37/continuous.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/.kokoro/environment/functions_37/presubmit.cfg
+++ b/.kokoro/environment/functions_37/presubmit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -20,6 +20,7 @@ required_envvars+=()
 # Add env vars which are passed down into the container here.
 pass_down_envvars+=(
     "ENVIRONMENT"
+    "RUNTIME"
     "STAGING_BUCKET"
     "V2_STAGING_BUCKET"
     "NOX_SESSION"

--- a/synth.py
+++ b/synth.py
@@ -77,7 +77,7 @@ s.replace(
 s.replace(
     ".trampolinerc",
     "pass_down_envvars\+\=\(",
-    'pass_down_envvars+=(\n    "ENVIRONMENT"'
+    'pass_down_envvars+=(\n    "ENVIRONMENT"\n    "RUNTIME"'
 )
 
 # don't lint environment tests


### PR DESCRIPTION
The Cloud Functions environment has significant changes between legacy (python38) and modern (python38, python38) runtimes. Since the Python 3.7 environment is sticking around, we should add a new environment test to check against it specifically. This PR adds a new kokoro config for this reason