### PR TITLE
fix: logger uses default resource

### DIFF
--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -20,6 +20,7 @@ from google.cloud.logging_v2.entries import ProtobufEntry
 from google.cloud.logging_v2.entries import StructEntry
 from google.cloud.logging_v2.entries import TextEntry
 from google.cloud.logging_v2.resource import Resource
+from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
 
 
 _GLOBAL_RESOURCE = Resource(type="global", labels={})
@@ -62,6 +63,7 @@ class Logger(object):
         self.name = name
         self._client = client
         self.labels = labels
+        self.default_resource = detect_resource(client.project)
 
     @property
     def client(self):
@@ -120,7 +122,7 @@ class Logger(object):
         # Apply defaults
         kw["log_name"] = kw.pop("log_name", self.full_name)
         kw["labels"] = kw.pop("labels", self.labels)
-        kw["resource"] = kw.pop("resource", _GLOBAL_RESOURCE)
+        kw["resource"] = kw.pop("resource", self.default_resource)
 
         if payload is not None:
             entry = _entry_class(payload=payload, **kw)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -99,11 +99,13 @@ class TestLogger(unittest.TestCase):
         self.assertIs(batch.client, client2)
 
     def test_log_empty_defaults_w_default_labels(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
-                "resource": {"type": "global", "labels": {}},
+                "resource": detect_resource(self.PROJECT)._to_dict(),
                 "labels": DEFAULT_LABELS,
             }
         ]
@@ -170,12 +172,14 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_defaults(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        RESOURCE = detect_resource(self.PROJECT)._to_dict()
         TEXT = "TEXT"
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "textPayload": TEXT,
-                "resource": {"type": "global", "labels": {}},
+                "resource": RESOURCE,
             }
         ]
         client = _Client(self.PROJECT)
@@ -187,13 +191,15 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_w_unicode_and_default_labels(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
         TEXT = "TEXT"
+        RESOURCE = detect_resource(self.PROJECT)._to_dict()
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "textPayload": TEXT,
-                "resource": {"type": "global", "labels": {}},
+                "resource": RESOURCE,
                 "labels": DEFAULT_LABELS,
             }
         ]
@@ -263,12 +269,14 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_defaults(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
+        RESOURCE = detect_resource(self.PROJECT)._to_dict()
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "jsonPayload": STRUCT,
-                "resource": {"type": "global", "labels": {}},
+                "resource": RESOURCE,
             }
         ]
         client = _Client(self.PROJECT)
@@ -280,13 +288,15 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_w_default_labels(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
+        RESOURCE = detect_resource(self.PROJECT)._to_dict()
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "jsonPayload": STRUCT,
-                "resource": {"type": "global", "labels": {}},
+                "resource": RESOURCE,
                 "labels": DEFAULT_LABELS,
             }
         ]
@@ -359,13 +369,14 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "protoPayload": json.loads(MessageToJson(message)),
-                "resource": {"type": "global", "labels": {}},
+                "resource": detect_resource(self.PROJECT)._to_dict(),
             }
         ]
         client = _Client(self.PROJECT)
@@ -380,6 +391,7 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
+        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         DEFAULT_LABELS = {"foo": "spam"}
@@ -387,7 +399,7 @@ class TestLogger(unittest.TestCase):
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "protoPayload": json.loads(MessageToJson(message)),
-                "resource": {"type": "global", "labels": {}},
+                "resource": detect_resource(self.PROJECT)._to_dict(),
                 "labels": DEFAULT_LABELS,
             }
         ]

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -99,7 +99,9 @@ class TestLogger(unittest.TestCase):
         self.assertIs(batch.client, client2)
 
     def test_log_empty_defaults_w_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
 
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
@@ -172,7 +174,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_defaults(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
+
         RESOURCE = detect_resource(self.PROJECT)._to_dict()
         TEXT = "TEXT"
         ENTRIES = [
@@ -191,7 +196,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_w_unicode_and_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
+
         TEXT = "TEXT"
         RESOURCE = detect_resource(self.PROJECT)._to_dict()
         DEFAULT_LABELS = {"foo": "spam"}
@@ -269,7 +277,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_defaults(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
+
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
         RESOURCE = detect_resource(self.PROJECT)._to_dict()
         ENTRIES = [
@@ -288,7 +299,10 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_w_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
+
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
         RESOURCE = detect_resource(self.PROJECT)._to_dict()
         DEFAULT_LABELS = {"foo": "spam"}
@@ -369,7 +383,9 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         ENTRIES = [
@@ -391,7 +407,9 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
-        from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         DEFAULT_LABELS = {"foo": "spam"}


### PR DESCRIPTION
We recently made changes to allow default resource auto-detection when using the logging handlers. This PR adds the same feature to regular Logger objects for better feature parity.

This PR also pulls in refactored environment tests from the submodule repo

