### PR TITLE
test: rennovate bot pulls in submodule changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base",  ":preserveSemverRanges"
-  ]
+  ],
+  "git-submodules": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
experimental change. Set renovate-bot to open PRs when the submodule updates, instead of putting them through PRs manually
