### PR TITLE
fix: revert default resource behavior to avoid breaking changes

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -16,6 +16,8 @@
 
 import logging
 
+
+from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 from google.cloud.logging_v2.handlers.transports import BackgroundThreadTransport
 from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
 
@@ -61,7 +63,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         *,
         name=DEFAULT_LOGGER_NAME,
         transport=BackgroundThreadTransport,
-        resource=None,
+        resource=_GLOBAL_RESOURCE,
         labels=None,
         stream=None,
     ):
@@ -80,15 +82,12 @@ class CloudLoggingHandler(logging.StreamHandler):
                 :class:`.BackgroundThreadTransport`. The other
                 option is :class:`.SyncTransport`.
             resource (~logging_v2.resource.Resource):
-                Resource for this Handler. If not given, will be inferred from the environment.
+                Resource for this Handler. Defaults to ``GLOBAL_RESOURCE``.
             labels (Optional[dict]): Monitored resource of the entry, defaults
                 to the global resource type.
             stream (Optional[IO]): Stream to be used by the handler.
         """
         super(CloudLoggingHandler, self).__init__(stream)
-        if not resource:
-            # infer the correct monitored resource from the local environment
-            resource = detect_resource(client.project)
         self.name = name
         self.client = client
         self.transport = transport(client, name)

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -82,7 +82,7 @@ class CloudLoggingHandler(logging.StreamHandler):
                 :class:`.BackgroundThreadTransport`. The other
                 option is :class:`.SyncTransport`.
             resource (~logging_v2.resource.Resource):
-                Resource for this Handler. Defaults to ``GLOBAL_RESOURCE``.
+                Resource for this Handler. Defaults to ``global``.
             labels (Optional[dict]): Monitored resource of the entry, defaults
                 to the global resource type.
             stream (Optional[IO]): Stream to be used by the handler.

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -20,7 +20,6 @@ from google.cloud.logging_v2.entries import ProtobufEntry
 from google.cloud.logging_v2.entries import StructEntry
 from google.cloud.logging_v2.entries import TextEntry
 from google.cloud.logging_v2.resource import Resource
-from google.cloud.logging_v2.handlers._monitored_resources import detect_resource
 
 
 _GLOBAL_RESOURCE = Resource(type="global", labels={})
@@ -49,13 +48,15 @@ class Logger(object):
     See https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.logs
     """
 
-    def __init__(self, name, client, *, labels=None):
+    def __init__(self, name, client, *, labels=None, resource=_GLOBAL_RESOURCE):
         """
         Args:
             name (str): The name of the logger.
             client (~logging_v2.client.Client):
                 A client which holds credentials and project configuration
                 for the logger (which requires a project).
+            resource (~logging_v2.Resource): a monitored resource object
+                representing the resource the code was run on.
             labels (Optional[dict]): Mapping of default labels for entries written
                 via this logger.
 
@@ -63,7 +64,7 @@ class Logger(object):
         self.name = name
         self._client = client
         self.labels = labels
-        self.default_resource = detect_resource(client.project)
+        self.default_resource = resource
 
     @property
     def client(self):

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -38,9 +38,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
 
     def test_ctor_defaults(self):
         import sys
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            _create_global_resource,
-        )
+        from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
         from google.cloud.logging_v2.handlers.handlers import DEFAULT_LOGGER_NAME
 
         patch = mock.patch(
@@ -55,8 +53,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
             self.assertIsInstance(handler.transport, _Transport)
             self.assertIs(handler.transport.client, client)
             self.assertEqual(handler.transport.name, DEFAULT_LOGGER_NAME)
-            global_resource = _create_global_resource(self.PROJECT)
-            self.assertEqual(handler.resource, global_resource)
+            self.assertEqual(handler.resource, _GLOBAL_RESOURCE)
             self.assertIsNone(handler.labels)
             self.assertIs(handler.stream, sys.stderr)
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -107,7 +107,7 @@ class TestLogger(unittest.TestCase):
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
-                "resource": detect_resource(self.PROJECT)._to_dict(),
+                "resource": {"type": "global", "labels": {}},
                 "labels": DEFAULT_LABELS,
             }
         ]
@@ -178,7 +178,7 @@ class TestLogger(unittest.TestCase):
             detect_resource,
         )
 
-        RESOURCE = detect_resource(self.PROJECT)._to_dict()
+        RESOURCE = {"type": "global", "labels": {}}
         TEXT = "TEXT"
         ENTRIES = [
             {
@@ -201,7 +201,7 @@ class TestLogger(unittest.TestCase):
         )
 
         TEXT = "TEXT"
-        RESOURCE = detect_resource(self.PROJECT)._to_dict()
+        RESOURCE = {"type": "global", "labels": {}}
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
@@ -282,7 +282,7 @@ class TestLogger(unittest.TestCase):
         )
 
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
-        RESOURCE = detect_resource(self.PROJECT)._to_dict()
+        RESOURCE = {"type": "global", "labels": {}}
         ENTRIES = [
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
@@ -304,7 +304,7 @@ class TestLogger(unittest.TestCase):
         )
 
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
-        RESOURCE = detect_resource(self.PROJECT)._to_dict()
+        RESOURCE = {"type": "global", "labels": {}}
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
@@ -392,7 +392,7 @@ class TestLogger(unittest.TestCase):
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "protoPayload": json.loads(MessageToJson(message)),
-                "resource": detect_resource(self.PROJECT)._to_dict(),
+                "resource": {"type": "global", "labels": {}},
             }
         ]
         client = _Client(self.PROJECT)
@@ -417,7 +417,7 @@ class TestLogger(unittest.TestCase):
             {
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
                 "protoPayload": json.loads(MessageToJson(message)),
-                "resource": detect_resource(self.PROJECT)._to_dict(),
+                "resource": {"type": "global", "labels": {}},
                 "labels": DEFAULT_LABELS,
             }
         ]

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -99,10 +99,6 @@ class TestLogger(unittest.TestCase):
         self.assertIs(batch.client, client2)
 
     def test_log_empty_defaults_w_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
-
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {
@@ -174,10 +170,6 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_defaults(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
-
         RESOURCE = {"type": "global", "labels": {}}
         TEXT = "TEXT"
         ENTRIES = [
@@ -196,10 +188,6 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_w_unicode_and_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
-
         TEXT = "TEXT"
         RESOURCE = {"type": "global", "labels": {}}
         DEFAULT_LABELS = {"foo": "spam"}
@@ -277,10 +265,6 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_defaults(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
-
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
         RESOURCE = {"type": "global", "labels": {}}
         ENTRIES = [
@@ -299,10 +283,6 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_struct_w_default_labels(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
-
         STRUCT = {"message": "MESSAGE", "weather": "cloudy"}
         RESOURCE = {"type": "global", "labels": {}}
         DEFAULT_LABELS = {"foo": "spam"}
@@ -383,9 +363,6 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         ENTRIES = [
@@ -407,9 +384,6 @@ class TestLogger(unittest.TestCase):
         import json
         from google.protobuf.json_format import MessageToJson
         from google.protobuf.struct_pb2 import Struct, Value
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
 
         message = Struct(fields={"foo": Value(bool_value=True)})
         DEFAULT_LABELS = {"foo": "spam"}


### PR DESCRIPTION
We recently added some changes to better auto-detect monitored resources in the environment (https://github.com/googleapis/python-logging/pull/200, https://github.com/googleapis/python-logging/pull/207). unfortunately, some of these changes ended up breaking existing workflows, which relied on a defailt `global` resource (https://github.com/googleapis/python-logging/issues/233).

This PR reverts auto-detection in the case where the API previously provided a default behavior. An auto-detected `resource` will still be added when using `setup_logging`, as that is in line with the existing API contract.

This PR will be reverted at version v3.0.0 to make resource auto-detection the standard