### PR TITLE
feat: Improve source location overrides

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -152,7 +152,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         trace_id = getattr(record, "trace", None)
         span_id = getattr(record, "span_id", None)
         http_request = getattr(record, "http_request", None)
-        source_location = getattr(record "source_location", None)
+        source_location = getattr(record, "source_location", None)
         resource = getattr(record, "resource", self.resource)
         user_labels = getattr(record, "labels", {})
         # merge labels

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,7 +50,7 @@ class CloudLoggingFilter(logging.Filter):
             record.line = record.lineno if record.lineno else 0
             record.file = record.pathname if record.pathname else ""
             record.function = record.funcName if record.funcName else ""
-            if any(record.line, record.file, record.function):
+            if any([record.line, record.file, record.function]):
                 record.source_location = {
                     "line": record.line,
                     "file": record.file,

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,6 +50,12 @@ class CloudLoggingFilter(logging.Filter):
             record.line = record.lineno if record.lineno else 0
             record.file = record.pathname if record.pathname else ""
             record.function = record.funcName if record.funcName else ""
+            if any(record.line, record.file, record.function):
+                record.source_location = {
+                    "line": record.line,
+                    "file": record.file,
+                    "function": record.function,
+                }
         record.msg = "" if record.msg is None else record.msg
         # find http request data
         inferred_http, inferred_trace = get_request_data()
@@ -146,6 +152,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         trace_id = getattr(record, "trace", None)
         span_id = getattr(record, "span_id", None)
         http_request = getattr(record, "http_request", None)
+        source_location = getattr(record "source_location", None)
         resource = getattr(record, "resource", self.resource)
         user_labels = getattr(record, "labels", {})
         # merge labels
@@ -162,6 +169,7 @@ class CloudLoggingHandler(logging.StreamHandler):
             trace=trace_id,
             span_id=span_id,
             http_request=http_request,
+            source_location=source_location,
         )
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -42,10 +42,15 @@ class CloudLoggingFilter(logging.Filter):
 
     def filter(self, record):
         # ensure record has all required fields set
-        record.lineno = 0 if record.lineno is None else record.lineno
+        if hasattr(record, "source_location"):
+            record.line = int(record.source_location.get("line", 0))
+            record.file = record.source_location.get("file", "")
+            record.function = record.source_location.get("function", "")
+        else:
+            record.line = record.lineno if record.lineno else 0
+            record.file = record.pathname if record.pathname else ""
+            record.function = record.funcName if record.funcName else ""
         record.msg = "" if record.msg is None else record.msg
-        record.funcName = "" if record.funcName is None else record.funcName
-        record.pathname = "" if record.pathname is None else record.pathname
         # find http request data
         inferred_http, inferred_trace = get_request_data()
         if inferred_trace is not None and self.project is not None:

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -137,6 +137,8 @@ class CloudLoggingHandler(logging.StreamHandler):
         self.project_id = client.project
         self.resource = resource
         self.labels = labels
+        # add extra keys to log record
+        self.addFilter(CloudLoggingFilter(self.project_id))
 
     def emit(self, record):
         """Actually log the specified logging record.

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,7 +19,7 @@ import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
-GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(pathname)s", "line": "%(lineno)d", "function": "%(funcName)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
 
 
 class StructuredLogHandler(logging.StreamHandler):

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -333,10 +333,12 @@ class TestLogging(unittest.TestCase):
             cloud_logger = logging.getLogger(LOGGER_NAME)
             cloud_logger.addHandler(handler)
             expected_request = {"requestUrl": "localhost"}
+            expected_source = {"file": "test.py"}
             extra = {
                 "trace": "123",
                 "span_id": "456",
                 "http_request": expected_request,
+                "source_location": expected_source,
                 "resource": Resource(type="cloudiot_device", labels={}),
                 "labels": {"test-label": "manual"},
             }

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -67,10 +67,10 @@ class TestCloudLoggingFilter(unittest.TestCase):
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.lineno, lineno)
+        self.assertEqual(record.line, lineno)
         self.assertEqual(record.msg, message)
-        self.assertEqual(record.funcName, func)
-        self.assertEqual(record.pathname, pathname)
+        self.assertEqual(record.function, func)
+        self.assertEqual(record.file, pathname)
         self.assertEqual(record.trace, "")
         self.assertEqual(record.http_request, {})
         self.assertEqual(record.request_method, "")
@@ -91,10 +91,10 @@ class TestCloudLoggingFilter(unittest.TestCase):
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.lineno, 0)
+        self.assertEqual(record.line, 0)
         self.assertEqual(record.msg, "")
-        self.assertEqual(record.funcName, "")
-        self.assertEqual(record.pathname, "")
+        self.assertEqual(record.function, "")
+        self.assertEqual(record.file, "")
         self.assertEqual(record.trace, "")
         self.assertEqual(record.http_request, {})
         self.assertEqual(record.request_method, "")
@@ -175,7 +175,16 @@ class TestCloudLoggingFilter(unittest.TestCase):
                 "userAgent": overwritten_agent,
                 "protocol": overwritten_protocol,
             }
+            overwritten_line = 22
+            overwritten_function = "test-func"
+            overwritten_file = "test-file"
+            overwritten_source_location = {
+                "file": overwritten_file,
+                "line": overwritten_line,
+                "function": overwritten_function
+            }
             record.http_request = overwritten_request_object
+            record.source_location = overwritten_source_location
             success = filter_obj.filter(record)
             self.assertTrue(success)
 
@@ -185,6 +194,9 @@ class TestCloudLoggingFilter(unittest.TestCase):
             self.assertEqual(record.request_url, overwritten_url)
             self.assertEqual(record.user_agent, overwritten_agent)
             self.assertEqual(record.protocol, overwritten_protocol)
+            self.assertEqual(record.line, overwritten_line)
+            self.assertEqual(record.function, overwritten_function)
+            self.assertEqual(record.file, overwritten_file)
 
 
 class TestCloudLoggingHandler(unittest.TestCase):
@@ -256,12 +268,14 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
         logname = "loggername"
         message = "hello world"
+        labels = {'test-key': 'test-value'}
         record = logging.LogRecord(logname, logging, None, None, message, None, None)
+        record.labels = labels
         handler.emit(record)
 
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, _GLOBAL_RESOURCE, None, None, None, None),
+            (record, message, _GLOBAL_RESOURCE, labels, None, None, None),
         )
 
     def test_emit_manual_field_override(self):

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -275,7 +275,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
 
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, _GLOBAL_RESOURCE, labels, None, None, None),
+            (record, message, _GLOBAL_RESOURCE, labels, None, None, None, None),
         )
 
     def test_emit_manual_field_override(self):
@@ -296,6 +296,8 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "span_id", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
+        expected_source = {'file': 'test-file'}
+        setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)
         expected_labels = {"test-label": "manual"}
@@ -312,6 +314,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
                 expected_trace,
                 expected_span,
                 expected_http,
+                expected_source,
             ),
         )
 
@@ -427,6 +430,7 @@ class _Transport(object):
         trace=None,
         span_id=None,
         http_request=None,
+        source_location=None,
     ):
         self.send_called_with = (
             record,
@@ -436,4 +440,5 @@ class _Transport(object):
             trace,
             span_id,
             http_request,
+            source_location,
         )

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -181,7 +181,7 @@ class TestCloudLoggingFilter(unittest.TestCase):
             overwritten_source_location = {
                 "file": overwritten_file,
                 "line": overwritten_line,
-                "function": overwritten_function
+                "function": overwritten_function,
             }
             record.http_request = overwritten_request_object
             record.source_location = overwritten_source_location
@@ -268,7 +268,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
         logname = "loggername"
         message = "hello world"
-        labels = {'test-key': 'test-value'}
+        labels = {"test-key": "test-value"}
         record = logging.LogRecord(logname, logging, None, None, message, None, None)
         record.labels = labels
         handler.emit(record)
@@ -296,7 +296,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "span_id", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
-        expected_source = {'file': 'test-file'}
+        expected_source = {"file": "test-file"}
         setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -166,7 +166,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         inferred_path = "http://testserver/123"
         overwrite_trace = "456"
         inferred_trace = "123"
-        overwrite_file = 'test-file'
+        overwrite_file = "test-file"
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
@@ -175,7 +175,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/sourceLocation": {
                 "file": overwrite_file,
                 "function": "",
-                "line": "0"
+                "line": "0",
             },
             "httpRequest": {
                 "requestMethod": "",
@@ -190,9 +190,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             c.put(
                 path=inferred_path,
                 data="body",
-                headers={
-                    "X_CLOUD_TRACE_CONTEXT": inferred_trace,
-                },
+                headers={"X_CLOUD_TRACE_CONTEXT": inferred_trace},
             )
             handler.filter(record)
             result = json.loads(handler.format(record))

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -196,6 +196,5 @@ class TestStructuredLogHandler(unittest.TestCase):
             )
             handler.filter(record)
             result = json.loads(handler.format(record))
-            breakpoint()
             for (key, value) in expected_payload.items():
                 self.assertEqual(value, result[key])

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -152,8 +152,10 @@ class TestStructuredLogHandler(unittest.TestCase):
 
     def test_format_overrides(self):
         """
-        Even if the environment provides source_location and http_request values,
-        the handler should prefer user inputs
+        Allow users to override log fields using `logging.info("", extra={})`
+
+        If supported fields were overriden by the user, those choices should
+        take precedence.
         """
         import logging
         import json

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -149,3 +149,53 @@ class TestStructuredLogHandler(unittest.TestCase):
             result = json.loads(handler.format(record))
             for (key, value) in expected_payload.items():
                 self.assertEqual(value, result[key])
+
+    def test_format_overrides(self):
+        """
+        Even if the environment provides source_location and http_request values,
+        the handler should prefer user inputs
+        """
+        import logging
+        import json
+
+        handler = self._make_one()
+        logname = "loggername"
+        message = "hello world，嗨 世界"
+        record = logging.LogRecord(logname, logging.INFO, "", 0, message, None, None)
+        overwrite_path = "http://overwrite"
+        inferred_path = "http://testserver/123"
+        overwrite_trace = "456"
+        inferred_trace = "123"
+        overwrite_file = 'test-file'
+        record.http_request = {"requestUrl": overwrite_path}
+        record.source_location = {"file": overwrite_file}
+        record.trace = overwrite_trace
+        expected_payload = {
+            "logging.googleapis.com/trace": overwrite_trace,
+            "logging.googleapis.com/sourceLocation": {
+                "file": overwrite_file,
+                "function": "",
+                "line": "0"
+            },
+            "httpRequest": {
+                "requestMethod": "",
+                "requestUrl": overwrite_path,
+                "userAgent": "",
+                "protocol": "",
+            },
+        }
+
+        app = self.create_app()
+        with app.test_client() as c:
+            c.put(
+                path=inferred_path,
+                data="body",
+                headers={
+                    "X_CLOUD_TRACE_CONTEXT": inferred_trace,
+                },
+            )
+            handler.filter(record)
+            result = json.loads(handler.format(record))
+            breakpoint()
+            for (key, value) in expected_payload.items():
+                self.assertEqual(value, result[key])


### PR DESCRIPTION
- I improved how source_entries are handled in the CloudLoggingFilter, to better match the LogEntry spec
- I added a bunch of tests around user overrides for `http_request`, `trace`, `resource`, and `source_location` fields