### PR TITLE
feat: allow custom labels with standard library logging

### DIFF
--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -362,9 +362,9 @@ class Client(ClientWithProject):
             ):
                 # Cloud Functions with runtimes > 3.8 supports structured logs on standard out
                 # 3.7 should use the standard CloudLoggingHandler, which sends logs over the network.
-                return StructuredLogHandler(**kw, project=self.project)
+                return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:
-                return StructuredLogHandler(**kw, project=self.project)
+                return StructuredLogHandler(**kw, project_id=self.project)
         return CloudLoggingHandler(self, resource=monitored_resource, **kw)
 
     def setup_logging(

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -152,7 +152,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         trace_id = getattr(record, "trace", None)
         span_id = getattr(record, "span_id", None)
         http_request = getattr(record, "http_request", None)
-        source_location = getattr(record "source_location", None)
+        source_location = getattr(record, "source_location", None)
         resource = getattr(record, "resource", self.resource)
         user_labels = getattr(record, "labels", {})
         # merge labels

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -65,7 +65,7 @@ class CloudLoggingFilter(logging.Filter):
         # set labels
         user_labels = getattr(record, "labels", {})
         record.total_labels = {**self.default_labels, **user_labels}
-        record.total_labels_str = str(record.total_labels)
+        record.total_labels_str =  ", ".join([f'"{k}": "{v}"' for k,v in record.total_labels.items()])
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,7 +50,7 @@ class CloudLoggingFilter(logging.Filter):
             record.line = record.lineno if record.lineno else 0
             record.file = record.pathname if record.pathname else ""
             record.function = record.funcName if record.funcName else ""
-            if any(record.line, record.file, record.function):
+            if any([record.line, record.file, record.function]):
                 record.source_location = {
                     "line": record.line,
                     "file": record.file,

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,6 +50,12 @@ class CloudLoggingFilter(logging.Filter):
             record.line = record.lineno if record.lineno else 0
             record.file = record.pathname if record.pathname else ""
             record.function = record.funcName if record.funcName else ""
+            if any(record.line, record.file, record.function):
+                record.source_location = {
+                    "line": record.line,
+                    "file": record.file,
+                    "function": record.function,
+                }
         record.msg = "" if record.msg is None else record.msg
         # find http request data
         inferred_http, inferred_trace = get_request_data()
@@ -146,6 +152,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         trace_id = getattr(record, "trace", None)
         span_id = getattr(record, "span_id", None)
         http_request = getattr(record, "http_request", None)
+        source_location = getattr(record "source_location", None)
         resource = getattr(record, "resource", self.resource)
         user_labels = getattr(record, "labels", {})
         # merge labels
@@ -162,6 +169,7 @@ class CloudLoggingHandler(logging.StreamHandler):
             trace=trace_id,
             span_id=span_id,
             http_request=http_request,
+            source_location=source_location,
         )
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -65,6 +65,7 @@ class CloudLoggingFilter(logging.Filter):
         # set labels
         user_labels = getattr(record, "labels", {})
         record.total_labels = {**self.default_labels, **user_labels}
+        record.total_labels_str = str(record.total_labels)
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}
@@ -139,6 +140,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         self.transport = transport(client, name)
         self.project_id = client.project
         self.resource = resource
+        self.labels = labels
         # add extra keys to log record
         log_filter = CloudLoggingFilter(project=self.project_id, default_labels=labels)
         self.addFilter(log_filter)
@@ -159,11 +161,11 @@ class CloudLoggingHandler(logging.StreamHandler):
             record,
             message,
             resource=getattr(record, "resource", self.resource),
-            labels=getattr(record, "total_labels", None),
-            trace=getattr(record, "trace", None),
-            span_id=getattr(record, "span_id", None),
-            http_request=getattr(record, "http_request", None),
-            source_location=getattr(record, "source_location", None),
+            labels=getattr(record, "total_labels", None) or None,
+            trace=getattr(record, "trace", None) or None,
+            span_id=getattr(record, "span_id", None) or None,
+            http_request=getattr(record, "http_request", None) or None,
+            source_location=getattr(record, "source_location", None) or None,
         )
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -42,10 +42,15 @@ class CloudLoggingFilter(logging.Filter):
 
     def filter(self, record):
         # ensure record has all required fields set
-        record.lineno = 0 if record.lineno is None else record.lineno
+        if hasattr(record, "source_location"):
+            record.line = int(record.source_location.get("line", 0))
+            record.file = record.source_location.get("file", "")
+            record.function = record.source_location.get("function", "")
+        else:
+            record.line = record.lineno if record.lineno else 0
+            record.file = record.pathname if record.pathname else ""
+            record.function = record.funcName if record.funcName else ""
         record.msg = "" if record.msg is None else record.msg
-        record.funcName = "" if record.funcName is None else record.funcName
-        record.pathname = "" if record.pathname is None else record.pathname
         # find http request data
         inferred_http, inferred_trace = get_request_data()
         if inferred_trace is not None and self.project is not None:

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -137,6 +137,8 @@ class CloudLoggingHandler(logging.StreamHandler):
         self.project_id = client.project
         self.resource = resource
         self.labels = labels
+        # add extra keys to log record
+        self.addFilter(CloudLoggingFilter(self.project_id))
 
     def emit(self, record):
         """Actually log the specified logging record.

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -65,7 +65,9 @@ class CloudLoggingFilter(logging.Filter):
         # set labels
         user_labels = getattr(record, "labels", {})
         record.total_labels = {**self.default_labels, **user_labels}
-        record.total_labels_str =  ", ".join([f'"{k}": "{v}"' for k,v in record.total_labels.items()])
+        record.total_labels_str = ", ".join(
+            [f'"{k}": "{v}"' for k, v in record.total_labels.items()]
+        )
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -37,8 +37,9 @@ class CloudLoggingFilter(logging.Filter):
     the `extras` argument when writing logs.
     """
 
-    def __init__(self, project=None):
+    def __init__(self, project=None, default_labels=None):
         self.project = project
+        self.default_labels = default_labels if default_labels else {}
 
     def filter(self, record):
         # ensure record has all required fields set
@@ -61,6 +62,9 @@ class CloudLoggingFilter(logging.Filter):
         inferred_http, inferred_trace = get_request_data()
         if inferred_trace is not None and self.project is not None:
             inferred_trace = f"projects/{self.project}/traces/{inferred_trace}"
+        # set labels
+        user_labels = getattr(record, "labels", {})
+        record.total_labels = {**self.default_labels, **user_labels}
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}
@@ -126,8 +130,7 @@ class CloudLoggingHandler(logging.StreamHandler):
                 option is :class:`.SyncTransport`.
             resource (~logging_v2.resource.Resource):
                 Resource for this Handler. Defaults to ``global``.
-            labels (Optional[dict]): Monitored resource of the entry, defaults
-                to the global resource type.
+            labels (Optional[dict]): Additional labels to attach to logs.
             stream (Optional[IO]): Stream to be used by the handler.
         """
         super(CloudLoggingHandler, self).__init__(stream)
@@ -136,9 +139,9 @@ class CloudLoggingHandler(logging.StreamHandler):
         self.transport = transport(client, name)
         self.project_id = client.project
         self.resource = resource
-        self.labels = labels
         # add extra keys to log record
-        self.addFilter(CloudLoggingFilter(self.project_id))
+        log_filter = CloudLoggingFilter(project=self.project_id, default_labels=labels)
+        self.addFilter(log_filter)
 
     def emit(self, record):
         """Actually log the specified logging record.
@@ -151,18 +154,12 @@ class CloudLoggingHandler(logging.StreamHandler):
             record (logging.LogRecord): The record to be logged.
         """
         message = super(CloudLoggingHandler, self).format(record)
-        user_labels = getattr(record, "labels", {})
-        # merge labels
-        total_labels = self.labels if self.labels is not None else {}
-        total_labels.update(user_labels)
-        if len(total_labels) == 0:
-            total_labels = None
         # send off request
         self.transport.send(
             record,
             message,
             resource=getattr(record, "resource", self.resource),
-            labels=total_labels,
+            labels=getattr(record, "total_labels", None),
             trace=getattr(record, "trace", None),
             span_id=getattr(record, "span_id", None),
             http_request=getattr(record, "http_request", None),

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,7 +19,7 @@ import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
-GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(pathname)s", "line": "%(lineno)d", "function": "%(funcName)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
 
 
 class StructuredLogHandler(logging.StreamHandler):

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,7 +19,7 @@ import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
-GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "labels": "%(total_labels)", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
 
 
 class StructuredLogHandler(logging.StreamHandler):
@@ -27,18 +27,20 @@ class StructuredLogHandler(logging.StreamHandler):
     and write them to standard output
     """
 
-    def __init__(self, *, name=None, stream=None, project=None):
+    def __init__(self, *, labels=None, stream=None, project=None):
         """
         Args:
-            name (Optional[str]): The name of the custom log in Cloud Logging.
+            labels (Optional[dict]): Additional labels to attach to logs.
             stream (Optional[IO]): Stream to be used by the handler.
+            project (Optional[str]): Project Id associated with the logs.
         """
         super(StructuredLogHandler, self).__init__(stream=stream)
         self.name = name
         self.project_id = project
 
         # add extra keys to log record
-        self.addFilter(CloudLoggingFilter(project))
+        log_filter = CloudLoggingFilter(project=project, default_labels=labels)
+        self.addFilter(log_filter)
 
         # make logs appear in GCP structured logging format
         self.formatter = logging.Formatter(GCP_FORMAT)

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -21,7 +21,7 @@ from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
 GCP_FORMAT = ('{"message": "%(message)s", '
         '"severity": "%(levelname)s", '
-        '"logging.googleapis.com/labels": "%(total_labels_str)s", '
+        '"logging.googleapis.com/labels": { %(total_labels_str)s }, '
         '"logging.googleapis.com/trace": "%(trace)s", '
         '"logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, '
         '"httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,7 +19,7 @@ import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
-GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "labels": "%(total_labels)", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+GCP_FORMAT = '{"message": "%(message)s", "severity": "%(levelname)s", "logging.googleapis.com/labels": "%(total_labels_str)s", "logging.googleapis.com/trace": "%(trace)s", "logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, "httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
 
 
 class StructuredLogHandler(logging.StreamHandler):
@@ -27,7 +27,7 @@ class StructuredLogHandler(logging.StreamHandler):
     and write them to standard output
     """
 
-    def __init__(self, *, labels=None, stream=None, project=None):
+    def __init__(self, *, labels=None, stream=None, project_id=None):
         """
         Args:
             labels (Optional[dict]): Additional labels to attach to logs.
@@ -35,11 +35,10 @@ class StructuredLogHandler(logging.StreamHandler):
             project (Optional[str]): Project Id associated with the logs.
         """
         super(StructuredLogHandler, self).__init__(stream=stream)
-        self.name = name
-        self.project_id = project
+        self.project_id = project_id
 
         # add extra keys to log record
-        log_filter = CloudLoggingFilter(project=project, default_labels=labels)
+        log_filter = CloudLoggingFilter(project=project_id, default_labels=labels)
         self.addFilter(log_filter)
 
         # make logs appear in GCP structured logging format

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,13 +19,14 @@ import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
-GCP_FORMAT = ('{"message": "%(message)s", '
-        '"severity": "%(levelname)s", '
-        '"logging.googleapis.com/labels": { %(total_labels_str)s }, '
-        '"logging.googleapis.com/trace": "%(trace)s", '
-        '"logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, '
-        '"httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
-    )
+GCP_FORMAT = (
+    '{"message": "%(message)s", '
+    '"severity": "%(levelname)s", '
+    '"logging.googleapis.com/labels": { %(total_labels_str)s }, '
+    '"logging.googleapis.com/trace": "%(trace)s", '
+    '"logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, '
+    '"httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+)
 
 
 class StructuredLogHandler(logging.StreamHandler):

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -333,10 +333,12 @@ class TestLogging(unittest.TestCase):
             cloud_logger = logging.getLogger(LOGGER_NAME)
             cloud_logger.addHandler(handler)
             expected_request = {"requestUrl": "localhost"}
+            expected_source = {"file": "test.py"}
             extra = {
                 "trace": "123",
                 "span_id": "456",
                 "http_request": expected_request,
+                "source_location": expected_source,
                 "resource": Resource(type="cloudiot_device", labels={}),
                 "labels": {"test-label": "manual"},
             }

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -280,9 +280,15 @@ class TestCloudLoggingHandler(unittest.TestCase):
         from google.cloud.logging_v2.resource import Resource
 
         client = _Client(self.PROJECT)
-        default_labels = {"default_key": "default-value", "overwritten_key":"bad_value"}
+        default_labels = {
+            "default_key": "default-value",
+            "overwritten_key": "bad_value",
+        }
         handler = self._make_one(
-            client, transport=_Transport, resource=_GLOBAL_RESOURCE, labels=default_labels
+            client,
+            transport=_Transport,
+            resource=_GLOBAL_RESOURCE,
+            labels=default_labels,
         )
         logname = "loggername"
         message = "hello world"
@@ -298,8 +304,12 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)
-        added_labels = {"added_key": "added_value", "overwritten_key":"new_value"}
-        expected_labels = {"default_key": "default-value", "overwritten_key":"new_value", "added_key": "added_value"}
+        added_labels = {"added_key": "added_value", "overwritten_key": "new_value"}
+        expected_labels = {
+            "default_key": "default-value",
+            "overwritten_key": "new_value",
+            "added_key": "added_value",
+        }
         setattr(record, "labels", added_labels)
         handler.handle(record)
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -268,13 +268,11 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
         logname = "loggername"
         message = "hello world"
-        labels = {"test-key": "test-value"}
         record = logging.LogRecord(logname, logging, None, None, message, None, None)
-        record.labels = labels
-        handler.emit(record)
+        handler.handle(record)
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, _GLOBAL_RESOURCE, labels, None, None, None, None),
+            (record, message, _GLOBAL_RESOURCE, None, None, None, None, None),
         )
 
     def test_emit_manual_field_override(self):
@@ -282,8 +280,9 @@ class TestCloudLoggingHandler(unittest.TestCase):
         from google.cloud.logging_v2.resource import Resource
 
         client = _Client(self.PROJECT)
+        default_labels = {"default_key": "default-value", "overwritten_key":"bad_value"}
         handler = self._make_one(
-            client, transport=_Transport, resource=_GLOBAL_RESOURCE
+            client, transport=_Transport, resource=_GLOBAL_RESOURCE, labels=default_labels
         )
         logname = "loggername"
         message = "hello world"
@@ -299,9 +298,10 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)
-        expected_labels = {"test-label": "manual"}
-        setattr(record, "labels", expected_labels)
-        handler.emit(record)
+        added_labels = {"added_key": "added_value", "overwritten_key":"new_value"}
+        expected_labels = {"default_key": "default-value", "overwritten_key":"new_value", "added_key": "added_value"}
+        setattr(record, "labels", added_labels)
+        handler.handle(record)
 
         self.assertEqual(
             handler.transport.send_called_with,

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -67,10 +67,10 @@ class TestCloudLoggingFilter(unittest.TestCase):
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.lineno, lineno)
+        self.assertEqual(record.line, lineno)
         self.assertEqual(record.msg, message)
-        self.assertEqual(record.funcName, func)
-        self.assertEqual(record.pathname, pathname)
+        self.assertEqual(record.function, func)
+        self.assertEqual(record.file, pathname)
         self.assertEqual(record.trace, "")
         self.assertEqual(record.http_request, {})
         self.assertEqual(record.request_method, "")
@@ -91,10 +91,10 @@ class TestCloudLoggingFilter(unittest.TestCase):
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.lineno, 0)
+        self.assertEqual(record.line, 0)
         self.assertEqual(record.msg, "")
-        self.assertEqual(record.funcName, "")
-        self.assertEqual(record.pathname, "")
+        self.assertEqual(record.function, "")
+        self.assertEqual(record.file, "")
         self.assertEqual(record.trace, "")
         self.assertEqual(record.http_request, {})
         self.assertEqual(record.request_method, "")
@@ -175,7 +175,16 @@ class TestCloudLoggingFilter(unittest.TestCase):
                 "userAgent": overwritten_agent,
                 "protocol": overwritten_protocol,
             }
+            overwritten_line = 22
+            overwritten_function = "test-func"
+            overwritten_file = "test-file"
+            overwritten_source_location = {
+                "file": overwritten_file,
+                "line": overwritten_line,
+                "function": overwritten_function
+            }
             record.http_request = overwritten_request_object
+            record.source_location = overwritten_source_location
             success = filter_obj.filter(record)
             self.assertTrue(success)
 
@@ -185,6 +194,9 @@ class TestCloudLoggingFilter(unittest.TestCase):
             self.assertEqual(record.request_url, overwritten_url)
             self.assertEqual(record.user_agent, overwritten_agent)
             self.assertEqual(record.protocol, overwritten_protocol)
+            self.assertEqual(record.line, overwritten_line)
+            self.assertEqual(record.function, overwritten_function)
+            self.assertEqual(record.file, overwritten_file)
 
 
 class TestCloudLoggingHandler(unittest.TestCase):
@@ -256,12 +268,14 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
         logname = "loggername"
         message = "hello world"
+        labels = {'test-key': 'test-value'}
         record = logging.LogRecord(logname, logging, None, None, message, None, None)
+        record.labels = labels
         handler.emit(record)
 
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, _GLOBAL_RESOURCE, None, None, None, None),
+            (record, message, _GLOBAL_RESOURCE, labels, None, None, None),
         )
 
     def test_emit_manual_field_override(self):

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -275,7 +275,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
 
         self.assertEqual(
             handler.transport.send_called_with,
-            (record, message, _GLOBAL_RESOURCE, labels, None, None, None),
+            (record, message, _GLOBAL_RESOURCE, labels, None, None, None, None),
         )
 
     def test_emit_manual_field_override(self):
@@ -296,6 +296,8 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "span_id", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
+        expected_source = {'file': 'test-file'}
+        setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)
         expected_labels = {"test-label": "manual"}
@@ -312,6 +314,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
                 expected_trace,
                 expected_span,
                 expected_http,
+                expected_source,
             ),
         )
 
@@ -427,6 +430,7 @@ class _Transport(object):
         trace=None,
         span_id=None,
         http_request=None,
+        source_location=None,
     ):
         self.send_called_with = (
             record,
@@ -436,4 +440,5 @@ class _Transport(object):
             trace,
             span_id,
             http_request,
+            source_location,
         )

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -181,7 +181,7 @@ class TestCloudLoggingFilter(unittest.TestCase):
             overwritten_source_location = {
                 "file": overwritten_file,
                 "line": overwritten_line,
-                "function": overwritten_function
+                "function": overwritten_function,
             }
             record.http_request = overwritten_request_object
             record.source_location = overwritten_source_location
@@ -268,7 +268,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
         logname = "loggername"
         message = "hello world"
-        labels = {'test-key': 'test-value'}
+        labels = {"test-key": "test-value"}
         record = logging.LogRecord(logname, logging, None, None, message, None, None)
         record.labels = labels
         handler.emit(record)
@@ -296,7 +296,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         setattr(record, "span_id", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
-        expected_source = {'file': 'test-file'}
+        expected_source = {"file": "test-file"}
         setattr(record, "source_location", expected_source)
         expected_resource = Resource(type="test", labels={})
         setattr(record, "resource", expected_resource)

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -166,7 +166,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         inferred_path = "http://testserver/123"
         overwrite_trace = "456"
         inferred_trace = "123"
-        overwrite_file = 'test-file'
+        overwrite_file = "test-file"
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
@@ -175,7 +175,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/sourceLocation": {
                 "file": overwrite_file,
                 "function": "",
-                "line": "0"
+                "line": "0",
             },
             "httpRequest": {
                 "requestMethod": "",
@@ -190,9 +190,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             c.put(
                 path=inferred_path,
                 data="body",
-                headers={
-                    "X_CLOUD_TRACE_CONTEXT": inferred_trace,
-                },
+                headers={"X_CLOUD_TRACE_CONTEXT": inferred_trace},
             )
             handler.filter(record)
             result = json.loads(handler.format(record))

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -75,7 +75,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": str(labels)
+            "logging.googleapis.com/labels": str(labels),
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -108,7 +108,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": "{}"
+            "logging.googleapis.com/labels": "{}",
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -163,7 +163,10 @@ class TestStructuredLogHandler(unittest.TestCase):
         import logging
         import json
 
-        default_labels = {"default_key": "default-value", "overwritten_key":"bad_value"}
+        default_labels = {
+            "default_key": "default-value",
+            "overwritten_key": "bad_value",
+        }
         handler = self._make_one(labels=default_labels)
         logname = "loggername"
         message = "hello world，嗨 世界"
@@ -176,7 +179,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
-        added_labels = {"added_key": "added_value", "overwritten_key":"new_value"}
+        added_labels = {"added_key": "added_value", "overwritten_key": "new_value"}
         record.labels = added_labels
         expected_payload = {
             "logging.googleapis.com/trace": overwrite_trace,
@@ -191,7 +194,13 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": str({"default_key": "default-value", "overwritten_key":"new_value", "added_key": "added_value"})
+            "logging.googleapis.com/labels": str(
+                {
+                    "default_key": "default-value",
+                    "overwritten_key": "new_value",
+                    "added_key": "added_value",
+                }
+            ),
         }
 
         app = self.create_app()

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -196,6 +196,5 @@ class TestStructuredLogHandler(unittest.TestCase):
             )
             handler.filter(record)
             result = json.loads(handler.format(record))
-            breakpoint()
             for (key, value) in expected_payload.items():
                 self.assertEqual(value, result[key])

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -152,8 +152,10 @@ class TestStructuredLogHandler(unittest.TestCase):
 
     def test_format_overrides(self):
         """
-        Even if the environment provides source_location and http_request values,
-        the handler should prefer user inputs
+        Allow users to override log fields using `logging.info("", extra={})`
+
+        If supported fields were overriden by the user, those choices should
+        take precedence.
         """
         import logging
         import json

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -40,17 +40,18 @@ class TestStructuredLogHandler(unittest.TestCase):
 
     def test_ctor_defaults(self):
         handler = self._make_one()
-        self.assertIsNone(handler.name)
+        self.assertIsNone(handler.project_id)
 
-    def test_ctor_w_name(self):
-        handler = self._make_one(name="foo")
-        self.assertEqual(handler.name, "foo")
+    def test_ctor_w_project(self):
+        handler = self._make_one(project_id="foo")
+        self.assertEqual(handler.project_id, "foo")
 
     def test_format(self):
         import logging
         import json
 
-        handler = self._make_one()
+        labels = {"default_key": "default-value"}
+        handler = self._make_one(labels=labels)
         logname = "loggername"
         message = "hello world，嗨 世界"
         pathname = "testpath"
@@ -74,6 +75,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
+            "logging.googleapis.com/labels": str(labels)
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -106,6 +108,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
+            "logging.googleapis.com/labels": "{}"
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -158,7 +161,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         import logging
         import json
 
-        handler = self._make_one()
+        default_labels = {"default_key": "default-value", "overwritten_key":"bad_value"}
+        handler = self._make_one(labels=default_labels)
         logname = "loggername"
         message = "hello world，嗨 世界"
         record = logging.LogRecord(logname, logging.INFO, "", 0, message, None, None)
@@ -170,6 +174,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
+        added_labels = {"added_key": "added_value", "overwritten_key":"new_value"}
+        record.labels = added_labels
         expected_payload = {
             "logging.googleapis.com/trace": overwrite_trace,
             "logging.googleapis.com/sourceLocation": {
@@ -183,6 +189,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
+            "logging.googleapis.com/labels": str({"default_key": "default-value", "overwritten_key":"new_value", "added_key": "added_value"})
         }
 
         app = self.create_app()

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -149,3 +149,53 @@ class TestStructuredLogHandler(unittest.TestCase):
             result = json.loads(handler.format(record))
             for (key, value) in expected_payload.items():
                 self.assertEqual(value, result[key])
+
+    def test_format_overrides(self):
+        """
+        Even if the environment provides source_location and http_request values,
+        the handler should prefer user inputs
+        """
+        import logging
+        import json
+
+        handler = self._make_one()
+        logname = "loggername"
+        message = "hello world，嗨 世界"
+        record = logging.LogRecord(logname, logging.INFO, "", 0, message, None, None)
+        overwrite_path = "http://overwrite"
+        inferred_path = "http://testserver/123"
+        overwrite_trace = "456"
+        inferred_trace = "123"
+        overwrite_file = 'test-file'
+        record.http_request = {"requestUrl": overwrite_path}
+        record.source_location = {"file": overwrite_file}
+        record.trace = overwrite_trace
+        expected_payload = {
+            "logging.googleapis.com/trace": overwrite_trace,
+            "logging.googleapis.com/sourceLocation": {
+                "file": overwrite_file,
+                "function": "",
+                "line": "0"
+            },
+            "httpRequest": {
+                "requestMethod": "",
+                "requestUrl": overwrite_path,
+                "userAgent": "",
+                "protocol": "",
+            },
+        }
+
+        app = self.create_app()
+        with app.test_client() as c:
+            c.put(
+                path=inferred_path,
+                data="body",
+                headers={
+                    "X_CLOUD_TRACE_CONTEXT": inferred_trace,
+                },
+            )
+            handler.filter(record)
+            result = json.loads(handler.format(record))
+            breakpoint()
+            for (key, value) in expected_payload.items():
+                self.assertEqual(value, result[key])

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -75,7 +75,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": str(labels),
+            "logging.googleapis.com/labels": labels,
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -108,7 +108,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": "{}",
+            "logging.googleapis.com/labels": {},
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
@@ -194,13 +194,11 @@ class TestStructuredLogHandler(unittest.TestCase):
                 "userAgent": "",
                 "protocol": "",
             },
-            "logging.googleapis.com/labels": str(
-                {
-                    "default_key": "default-value",
-                    "overwritten_key": "new_value",
-                    "added_key": "added_value",
-                }
-            ),
+            "logging.googleapis.com/labels": {
+                "default_key": "default-value",
+                "overwritten_key": "new_value",
+                "added_key": "added_value",
+            },
         }
 
         app = self.create_app()


### PR DESCRIPTION
The library now fully supports passing in extra labels when logging though the standard library

I also added a number of unit and environment tests around this new functionality
