### PR TITLE
feat: support span inference

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -121,7 +121,7 @@ def get_request_data_from_django():
 
 
 def _parse_trace_span(header):
-    """Given an X_CLOUD_TRACE header, extrace the trace and span ids.
+    """Given an X_CLOUD_TRACE header, extract the trace and span ids.
 
     Args:
         header (str): the string extracted from the X_CLOUD_TRACE header

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -119,6 +119,7 @@ def get_request_data_from_django():
 
     return http_request, trace_id, span_id
 
+
 def _parse_trace_span(header):
     """Given an X_CLOUD_TRACE header, extrace the trace and span ids.
 

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -137,7 +137,7 @@ def _parse_trace_span(header):
         try:
             header_suffix = split_header[1]
             # the span is the set of alphanumeric characters after the /
-            span_id = re.findall(r"\w+", header_suffix)[0]
+            span_id = re.findall(r"^\w+", header_suffix)[0]
         except IndexError:
             pass
     return trace_id, span_id

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -132,9 +132,9 @@ def _parse_trace_span(header):
     trace_id = None
     span_id = None
     if header:
-        split_header = header.split("/", 1)
-        trace_id = split_header[0]
         try:
+            split_header = header.split("/", 1)
+            trace_id = split_header[0]
             header_suffix = split_header[1]
             # the span is the set of alphanumeric characters after the /
             span_id = re.findall(r"^\w+", header_suffix)[0]

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -107,7 +107,7 @@ class AppEngineHandler(logging.StreamHandler):
             record (logging.LogRecord): The record to be logged.
         """
         message = super(AppEngineHandler, self).format(record)
-        inferred_http, inferred_trace = get_request_data()
+        inferred_http, inferred_trace, _ = get_request_data()
         if inferred_trace is not None:
             inferred_trace = f"projects/{self.project_id}/traces/{inferred_trace}"
         # allow user overrides

--- a/google/cloud/logging_v2/handlers/app_engine.py
+++ b/google/cloud/logging_v2/handlers/app_engine.py
@@ -90,7 +90,7 @@ class AppEngineHandler(logging.StreamHandler):
         """
         gae_labels = {}
 
-        _, trace_id = get_request_data()
+        _, trace_id, _ = get_request_data()
         if trace_id is not None:
             gae_labels[_TRACE_ID_LABEL] = trace_id
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -59,7 +59,7 @@ class CloudLoggingFilter(logging.Filter):
                 }
         record.msg = "" if record.msg is None else record.msg
         # find http request data
-        inferred_http, inferred_trace = get_request_data()
+        inferred_http, inferred_trace, inferred_span = get_request_data()
         if inferred_trace is not None and self.project is not None:
             inferred_trace = f"projects/{self.project}/traces/{inferred_trace}"
         # set labels
@@ -70,6 +70,7 @@ class CloudLoggingFilter(logging.Filter):
         )
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
+        record.span_id = getattr(record, "spanId", inferred_span) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}
         record.request_method = record.http_request.get("requestMethod", "")
         record.request_url = record.http_request.get("requestUrl", "")

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -70,7 +70,7 @@ class CloudLoggingFilter(logging.Filter):
         )
 
         record.trace = getattr(record, "trace", inferred_trace) or ""
-        record.span_id = getattr(record, "spanId", inferred_span) or ""
+        record.span_id = getattr(record, "span_id", inferred_span) or ""
         record.http_request = getattr(record, "http_request", inferred_http) or {}
         record.request_method = record.http_request.get("requestMethod", "")
         record.request_url = record.http_request.get("requestUrl", "")

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -24,6 +24,7 @@ GCP_FORMAT = (
     '"severity": "%(levelname)s", '
     '"logging.googleapis.com/labels": { %(total_labels_str)s }, '
     '"logging.googleapis.com/trace": "%(trace)s", '
+    '"logging.googleapis.com/spanId": "%(span_id)s", '
     '"logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, '
     '"httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
 )

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -300,6 +300,7 @@ class Test_get_request_data(unittest.TestCase):
         output = self._call_fut()
         self.assertEqual(output, (None, None, None))
 
+
 class Test__parse_trace_span(unittest.TestCase):
     @staticmethod
     def _call_fut(header):

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -17,8 +17,10 @@ import unittest
 import mock
 
 _FLASK_TRACE_ID = "flask-id"
+_FLASK_SPAN_ID = "span0flask"
 _FLASK_HTTP_REQUEST = {"requestUrl": "https://flask.palletsprojects.com/en/1.1.x/"}
 _DJANGO_TRACE_ID = "django-id"
+_DJANGO_SPAN_ID = "span0django"
 _DJANGO_HTTP_REQUEST = {"requestUrl": "https://www.djangoproject.com/"}
 
 
@@ -44,15 +46,17 @@ class Test_get_request_data_from_flask(unittest.TestCase):
     def test_no_context_header(self):
         app = self.create_app()
         with app.test_request_context(path="/", headers={}):
-            http_request, trace_id = self._call_fut()
+            http_request, trace_id, span_id = self._call_fut()
 
         self.assertIsNone(trace_id)
+        self.assertIsNone(span_id)
         self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_valid_context_header(self):
         flask_trace_header = "X_CLOUD_TRACE_CONTEXT"
         expected_trace_id = _FLASK_TRACE_ID
-        flask_trace_id = expected_trace_id + "/testspanid"
+        expected_span_id = _FLASK_SPAN_ID
+        flask_trace_id = f"{expected_trace_id}/{expected_span_id}"
 
         app = self.create_app()
         context = app.test_request_context(
@@ -60,9 +64,10 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         )
 
         with context:
-            http_request, trace_id = self._call_fut()
+            http_request, trace_id, span_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
+        self.assertEqual(span_id, expected_span_id)
         self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_http_request_populated(self):
@@ -84,7 +89,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
                 environ_base={"REMOTE_ADDR": expected_ip},
                 headers=headers,
             )
-            http_request, trace_id = self._call_fut()
+            http_request, *_ = self._call_fut()
 
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
@@ -99,7 +104,7 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         app = self.create_app()
         with app.test_client() as c:
             c.put(path=expected_path)
-            http_request, trace_id = self._call_fut()
+            http_request, *_ = self._call_fut()
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
@@ -135,17 +140,20 @@ class Test_get_request_data_from_django(unittest.TestCase):
 
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
-        http_request, trace_id = self._call_fut()
+        http_request, trace_id, span_id = self._call_fut()
+
         self.assertEqual(http_request["requestMethod"], "GET")
         self.assertIsNone(trace_id)
+        self.assertIsNone(span_id)
 
     def test_valid_context_header(self):
         from django.test import RequestFactory
         from google.cloud.logging_v2.handlers.middleware import request
 
         django_trace_header = "HTTP_X_CLOUD_TRACE_CONTEXT"
-        expected_trace_id = "testtraceiddjango"
-        django_trace_id = expected_trace_id + "/testspanid"
+        expected_span_id = _DJANGO_SPAN_ID
+        expected_trace_id = _DJANGO_TRACE_ID
+        django_trace_id = f"{expected_trace_id}/{expected_span_id}"
 
         django_request = RequestFactory().get(
             "/", **{django_trace_header: django_trace_id}
@@ -153,9 +161,10 @@ class Test_get_request_data_from_django(unittest.TestCase):
 
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
-        http_request, trace_id = self._call_fut()
+        http_request, trace_id, span_id = self._call_fut()
 
         self.assertEqual(trace_id, expected_trace_id)
+        self.assertEqual(span_id, expected_span_id)
         self.assertEqual(http_request["requestMethod"], "GET")
 
     def test_http_request_populated(self):
@@ -178,7 +187,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
 
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
-        http_request, trace_id = self._call_fut()
+        http_request, *_ = self._call_fut()
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
@@ -195,7 +204,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         django_request = RequestFactory().put(expected_path)
         middleware = request.RequestMiddleware(None)
         middleware.process_request(django_request)
-        http_request, trace_id = self._call_fut()
+        http_request, *_ = self._call_fut()
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["remoteIp"], "127.0.0.1")
@@ -226,8 +235,8 @@ class Test_get_request_data(unittest.TestCase):
         return django_mock, flask_mock, result
 
     def test_from_django(self):
-        django_expected = (_DJANGO_HTTP_REQUEST, _DJANGO_TRACE_ID)
-        flask_expected = (None, None)
+        django_expected = (_DJANGO_HTTP_REQUEST, _DJANGO_TRACE_ID, _DJANGO_SPAN_ID)
+        flask_expected = (None, None, None)
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
         self.assertEqual(output, django_expected)
 
@@ -235,8 +244,8 @@ class Test_get_request_data(unittest.TestCase):
         flask_mock.assert_not_called()
 
     def test_from_flask(self):
-        django_expected = (None, None)
-        flask_expected = (_FLASK_HTTP_REQUEST, _FLASK_TRACE_ID)
+        django_expected = (None, None, None)
+        flask_expected = (_FLASK_HTTP_REQUEST, _FLASK_TRACE_ID, _FLASK_SPAN_ID)
 
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
         self.assertEqual(output, flask_expected)
@@ -245,8 +254,8 @@ class Test_get_request_data(unittest.TestCase):
         flask_mock.assert_called_once_with()
 
     def test_from_django_and_flask(self):
-        django_expected = (_DJANGO_HTTP_REQUEST, _DJANGO_TRACE_ID)
-        flask_expected = (_FLASK_HTTP_REQUEST, _FLASK_TRACE_ID)
+        django_expected = (_DJANGO_HTTP_REQUEST, _DJANGO_TRACE_ID, _DJANGO_SPAN_ID)
+        flask_expected = (_FLASK_HTTP_REQUEST, _FLASK_TRACE_ID, _FLASK_SPAN_ID)
 
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
 
@@ -257,19 +266,19 @@ class Test_get_request_data(unittest.TestCase):
         flask_mock.assert_not_called()
 
     def test_missing_http_request(self):
-        flask_expected = (None, _FLASK_TRACE_ID)
-        django_expected = (None, _DJANGO_TRACE_ID)
+        flask_expected = (None, _FLASK_TRACE_ID, _FLASK_SPAN_ID)
+        django_expected = (None, _DJANGO_TRACE_ID, _DJANGO_TRACE_ID)
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
 
         # function only returns trace if http_request data is present
-        self.assertEqual(output, (None, None))
+        self.assertEqual(output, (None, None, None))
 
         django_mock.assert_called_once_with()
         flask_mock.assert_called_once_with()
 
     def test_missing_trace_id(self):
-        flask_expected = (_FLASK_HTTP_REQUEST, None)
-        django_expected = (None, _DJANGO_TRACE_ID)
+        flask_expected = (_FLASK_HTTP_REQUEST, None, None)
+        django_expected = (None, _DJANGO_TRACE_ID, _DJANGO_SPAN_ID)
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
 
         # trace_id is optional
@@ -279,14 +288,14 @@ class Test_get_request_data(unittest.TestCase):
         flask_mock.assert_called_once_with()
 
     def test_missing_both(self):
-        flask_expected = (None, None)
-        django_expected = (None, None)
+        flask_expected = (None, None, None)
+        django_expected = (None, None, None)
         django_mock, flask_mock, output = self._helper(django_expected, flask_expected)
-        self.assertEqual(output, (None, None))
+        self.assertEqual(output, (None, None, None))
 
         django_mock.assert_called_once_with()
         flask_mock.assert_called_once_with()
 
     def test_wo_libraries(self):
         output = self._call_fut()
-        self.assertEqual(output, (None, None))
+        self.assertEqual(output, (None, None, None))

--- a/tests/unit/handlers/test_app_engine.py
+++ b/tests/unit/handlers/test_app_engine.py
@@ -97,7 +97,7 @@ class TestAppEngineHandler(unittest.TestCase):
         expected_trace_id = f"projects/{self.PROJECT}/traces/{trace_id}"
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
-            return_value=(expected_http_request, trace_id),
+            return_value=(expected_http_request, trace_id, None),
         )
         with get_request_patch:
             # library integrations mocked to return test data
@@ -135,7 +135,7 @@ class TestAppEngineHandler(unittest.TestCase):
         inferred_trace_id = "trace-test"
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
-            return_value=(inferred_http_request, inferred_trace_id),
+            return_value=(inferred_http_request, inferred_trace_id, None),
         )
         with get_request_patch:
             # library integrations mocked to return test data
@@ -180,7 +180,7 @@ class TestAppEngineHandler(unittest.TestCase):
     def _get_gae_labels_helper(self, trace_id):
         get_request_patch = mock.patch(
             "google.cloud.logging_v2.handlers.app_engine.get_request_data",
-            return_value=(None, trace_id),
+            return_value=(None, trace_id, None),
         )
 
         client = mock.Mock(project=self.PROJECT, spec=["project"])

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -297,7 +297,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         expected_trace = "123"
         setattr(record, "trace", expected_trace)
         expected_span = "456"
-        setattr(record, "spanId", expected_span)
+        setattr(record, "span_id", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
         expected_source = {"file": "test-file"}

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -297,7 +297,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         expected_trace = "123"
         setattr(record, "trace", expected_trace)
         expected_span = "456"
-        setattr(record, "span_id", expected_span)
+        setattr(record, "spanId", expected_span)
         expected_http = {"reuqest_url": "manual"}
         setattr(record, "http_request", expected_http)
         expected_source = {"file": "test-file"}

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -64,6 +64,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             "message": message,
             "severity": record.levelname,
             "logging.googleapis.com/trace": "",
+            "logging.googleapis.com/spanId": "",
             "logging.googleapis.com/sourceLocation": {
                 "file": pathname,
                 "line": str(lineno),
@@ -128,8 +129,11 @@ class TestStructuredLogHandler(unittest.TestCase):
         expected_path = "http://testserver/123"
         expected_agent = "Mozilla/5.0"
         expected_trace = "123"
+        expected_span = "456"
+        trace_header = f"{expected_trace}/{expected_span};o=0"
         expected_payload = {
             "logging.googleapis.com/trace": expected_trace,
+            "logging.googleapis.com/spanId": expected_span,
             "httpRequest": {
                 "requestMethod": "PUT",
                 "requestUrl": expected_path,
@@ -145,7 +149,7 @@ class TestStructuredLogHandler(unittest.TestCase):
                 data="body",
                 headers={
                     "User-Agent": expected_agent,
-                    "X_CLOUD_TRACE_CONTEXT": expected_trace,
+                    "X_CLOUD_TRACE_CONTEXT": trace_header,
                 },
             )
             handler.filter(record)
@@ -173,16 +177,19 @@ class TestStructuredLogHandler(unittest.TestCase):
         record = logging.LogRecord(logname, logging.INFO, "", 0, message, None, None)
         overwrite_path = "http://overwrite"
         inferred_path = "http://testserver/123"
-        overwrite_trace = "456"
-        inferred_trace = "123"
+        overwrite_trace = "abc"
+        overwrite_span = "def"
+        inferred_trace_span = "123/456;"
         overwrite_file = "test-file"
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
+        record.spanId = overwrite_span
         added_labels = {"added_key": "added_value", "overwritten_key": "new_value"}
         record.labels = added_labels
         expected_payload = {
             "logging.googleapis.com/trace": overwrite_trace,
+            "logging.googleapis.com/spanId": overwrite_span,
             "logging.googleapis.com/sourceLocation": {
                 "file": overwrite_file,
                 "function": "",
@@ -206,7 +213,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             c.put(
                 path=inferred_path,
                 data="body",
-                headers={"X_CLOUD_TRACE_CONTEXT": inferred_trace},
+                headers={"X_CLOUD_TRACE_CONTEXT": inferred_trace_span},
             )
             handler.filter(record)
             result = json.loads(handler.format(record))

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -184,7 +184,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         record.http_request = {"requestUrl": overwrite_path}
         record.source_location = {"file": overwrite_file}
         record.trace = overwrite_trace
-        record.spanId = overwrite_span
+        record.span_id = overwrite_span
         added_labels = {"added_key": "added_value", "overwritten_key": "new_value"}
         record.labels = added_labels
         expected_payload = {


### PR DESCRIPTION
This PR adds automatic span detection, and allows users to override it by sending `spanId` in the `extras` dictionary.

The span format seems to be underdocument, so I based my span capture logic on [what the go library is doing](https://github.com/googleapis/google-cloud-go/blob/1dacadbbf57c5667e212af1cc2d135ff6084e6d3/logging/logging.go#L946).

