### PR TITLE
refactor: clean up CloudLoggingFilter

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -93,12 +93,6 @@ def get_request_data_from_django():
     if request is None:
         return None, None, None
 
-    # convert content_length to int if it exists
-    content_length = None
-    try:
-        content_length = int(request.META.get(_DJANGO_CONTENT_LENGTH))
-    except (ValueError, TypeError):
-        content_length = None
     # build http_request
     http_request = {
         "requestMethod": request.method,

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -68,10 +68,7 @@ def get_request_data_from_flask():
     http_request = {
         "requestMethod": flask.request.method,
         "requestUrl": flask.request.url,
-        "requestSize": flask.request.content_length,
         "userAgent": flask.request.user_agent.string,
-        "remoteIp": flask.request.remote_addr,
-        "referer": flask.request.referrer,
         "protocol": flask.request.environ.get(_PROTOCOL_HEADER),
     }
 
@@ -106,10 +103,7 @@ def get_request_data_from_django():
     http_request = {
         "requestMethod": request.method,
         "requestUrl": request.build_absolute_uri(),
-        "requestSize": content_length,
         "userAgent": request.META.get(_DJANGO_USERAGENT_HEADER),
-        "remoteIp": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
-        "referer": request.META.get(_DJANGO_REFERER_HEADER),
         "protocol": request.META.get(_PROTOCOL_HEADER),
     }
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,7 +50,7 @@ class CloudLoggingFilter(logging.Filter):
         inner_str = ""
         if input_dict is not None:
             inner_str =  ", ".join([f'"{k}": "{v}"' for k, v in input_dict.items()])
-        return "{{ {0} }}".format(inner_str)
+        return "{{{0}}}".format(inner_str)
 
     @staticmethod
     def _infer_source_location(record):

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -32,9 +32,9 @@ class CloudLoggingFilter(logging.Filter):
     """Python standard ``logging`` Filter class to add Cloud Logging
     information to each LogRecord.
 
-    When attached to a LogHandler, each incoming log will receive trace and
-    http_request related to the request. This data can be overwritten using
-    the `extras` argument when writing logs.
+    When attached to a LogHandler, each incoming log will be modified
+    to include new Cloud Logging relevant data. This data can be manually
+    overwritten using the `extras` argument when writing logs.
     """
 
     def __init__(self, project=None, default_labels=None):
@@ -66,6 +66,9 @@ class CloudLoggingFilter(logging.Filter):
             return output if output else None
 
     def filter(self, record):
+        """
+        Add new Cloud Logging data to each LogRecord as it comes in
+        """
         user_labels = getattr(record, "labels", {})
         inferred_http, inferred_trace, inferred_span = get_request_data()
         if inferred_trace is not None and self.project is not None:

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -14,6 +14,7 @@
 
 """Python :mod:`logging` handlers for Cloud Logging."""
 
+import json
 import logging
 
 from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
@@ -40,17 +41,6 @@ class CloudLoggingFilter(logging.Filter):
     def __init__(self, project=None, default_labels=None):
         self.project = project
         self.default_labels = default_labels if default_labels else {}
-
-    @staticmethod
-    def _dict_to_string(input_dict):
-        """
-        Helper function to print a dictionary in the format expected by Cloud Logging
-        https://cloud.google.com/logging/docs/structured-logging
-        """
-        inner_str = ""
-        if input_dict is not None:
-            inner_str =  ", ".join([f'"{k}": "{v}"' for k, v in input_dict.items()])
-        return "{{{0}}}".format(inner_str)
 
     @staticmethod
     def _infer_source_location(record):
@@ -85,9 +75,9 @@ class CloudLoggingFilter(logging.Filter):
         record._msg_str = record.msg or ""
         record._trace_str = record._trace or ""
         record._span_id_str = record._span_id or ""
-        record._http_request_str = CloudLoggingFilter._dict_to_string(record._http_request)
-        record._source_location_str = CloudLoggingFilter._dict_to_string(record._source_location)
-        record._labels_str = CloudLoggingFilter._dict_to_string(record._labels)
+        record._http_request_str = json.dumps(record._http_request or {})
+        record._source_location_str = json.dumps(record._source_location or {})
+        record._labels_str = json.dumps(record._labels or {})
         return True
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -50,7 +50,11 @@ class CloudLoggingFilter(logging.Filter):
         if hasattr(record, "source_location"):
             return record.source_location
         else:
-            name_map =[("line", "lineno"), ("file", "pathname"), ("function", "funcName")]
+            name_map = [
+                ("line", "lineno"),
+                ("file", "pathname"),
+                ("function", "funcName"),
+            ]
             output = {}
             for (gcp_name, std_lib_name) in name_map:
                 value = getattr(record, std_lib_name, None)

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -85,7 +85,7 @@ class CloudLoggingFilter(logging.Filter):
         record._msg_str = record.msg or ""
         record._trace_str = record._trace or ""
         record._span_id_str = record._span_id or ""
-        record._http_request_str = CloudLoggingFilter._dict_to_string(_http_request)
+        record._http_request_str = CloudLoggingFilter._dict_to_string(record._http_request)
         record._source_location_str = CloudLoggingFilter._dict_to_string(record._source_location)
         record._labels_str = CloudLoggingFilter._dict_to_string(record._labels)
         return True

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -41,6 +41,7 @@ class CloudLoggingFilter(logging.Filter):
         self.project = project
         self.default_labels = default_labels if default_labels else {}
 
+    @staticmethod
     def _dict_to_string(input_dict):
         """
         Helper function to print a dictionary in the format expected by Cloud Logging
@@ -51,6 +52,7 @@ class CloudLoggingFilter(logging.Filter):
             inner_str =  ", ".join([f'"{k}": "{v}"' for k, v in input_dict.items()])
         return "{{ {0} }}".format(inner_str)
 
+    @staticmethod
     def _infer_source_location(record):
         """Helper function to infer source location data from a LogRecord.
         Will default to record.source_location if already set
@@ -77,15 +79,15 @@ class CloudLoggingFilter(logging.Filter):
         record._trace = getattr(record, "trace", inferred_trace) or None
         record._span_id = getattr(record, "span_id", inferred_span) or None
         record._http_request = getattr(record, "http_request", inferred_http)
-        record._source_location = _infer_source_location(record)
+        record._source_location = CloudLoggingFilter._infer_source_location(record)
         record._labels = {**self.default_labels, **user_labels}
         # create guaranteed string representations for structured logging
         record._msg_str = record.msg or ""
         record._trace_str = record._trace or ""
         record._span_id_str = record._span_id or ""
-        record._http_request_str = _dict_to_string(_http_request)
-        record._source_location_str = _dict_to_string(record._source_location)
-        record._labels_str = _dict_to_string(record._labels)
+        record._http_request_str = CloudLoggingFilter._dict_to_string(_http_request)
+        record._source_location_str = CloudLoggingFilter._dict_to_string(record._source_location)
+        record._labels_str = CloudLoggingFilter._dict_to_string(record._labels)
         return True
 
 

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -22,11 +22,11 @@ from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 GCP_FORMAT = (
     '{"message": "%(message)s", '
     '"severity": "%(levelname)s", '
-    '"logging.googleapis.com/labels": { %(_labels_str)s }, '
+    '"logging.googleapis.com/labels": %(_labels_str)s, '
     '"logging.googleapis.com/trace": "%(_trace)s", '
     '"logging.googleapis.com/spanId": "%(_span_id)s", '
-    '"logging.googleapis.com/sourceLocation": { %(_source_location_str)s }, '
-    '"httpRequest": { %(_http_request_str)s }'
+    '"logging.googleapis.com/sourceLocation": %(_source_location_str)s, '
+    '"httpRequest": %(_http_request_str)s'
 )
 
 

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -26,7 +26,7 @@ GCP_FORMAT = (
     '"logging.googleapis.com/trace": "%(_trace_str)s", '
     '"logging.googleapis.com/spanId": "%(_span_id_str)s", '
     '"logging.googleapis.com/sourceLocation": %(_source_location_str)s, '
-    '"httpRequest": %(_http_request_str)s'
+    '"httpRequest": %(_http_request_str)s }'
 )
 
 

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -22,11 +22,11 @@ from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 GCP_FORMAT = (
     '{"message": "%(message)s", '
     '"severity": "%(levelname)s", '
-    '"logging.googleapis.com/labels": { %(total_labels_str)s }, '
-    '"logging.googleapis.com/trace": "%(trace)s", '
-    '"logging.googleapis.com/spanId": "%(span_id)s", '
-    '"logging.googleapis.com/sourceLocation": { "file": "%(file)s", "line": "%(line)d", "function": "%(function)s"}, '
-    '"httpRequest": {"requestMethod": "%(request_method)s", "requestUrl": "%(request_url)s", "userAgent": "%(user_agent)s", "protocol": "%(protocol)s"} }'
+    '"logging.googleapis.com/labels": { %(_labels_str)s }, '
+    '"logging.googleapis.com/trace": "%(_trace)s", '
+    '"logging.googleapis.com/spanId": "%(_span_id)s", '
+    '"logging.googleapis.com/sourceLocation": { "file": "%(_file)s", "line": "%(_line)d", "function": "%(_function)s"}, '
+    '"httpRequest": {"requestMethod": "%(_request_method)s", "requestUrl": "%(_request_url)s", "userAgent": "%(_user_agent)s", "protocol": "%(_protocol)s"} }'
 )
 
 

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -20,11 +20,11 @@ import logging.handlers
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
 
 GCP_FORMAT = (
-    '{"message": "%(message)s", '
+    '{"message": "%(_msg_str)s", '
     '"severity": "%(levelname)s", '
     '"logging.googleapis.com/labels": %(_labels_str)s, '
-    '"logging.googleapis.com/trace": "%(_trace)s", '
-    '"logging.googleapis.com/spanId": "%(_span_id)s", '
+    '"logging.googleapis.com/trace": "%(_trace_str)s", '
+    '"logging.googleapis.com/spanId": "%(_span_id_str)s", '
     '"logging.googleapis.com/sourceLocation": %(_source_location_str)s, '
     '"httpRequest": %(_http_request_str)s'
 )

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -25,8 +25,8 @@ GCP_FORMAT = (
     '"logging.googleapis.com/labels": { %(_labels_str)s }, '
     '"logging.googleapis.com/trace": "%(_trace)s", '
     '"logging.googleapis.com/spanId": "%(_span_id)s", '
-    '"logging.googleapis.com/sourceLocation": { "file": "%(_file)s", "line": "%(_line)d", "function": "%(_function)s"}, '
-    '"httpRequest": {"requestMethod": "%(_request_method)s", "requestUrl": "%(_request_url)s", "userAgent": "%(_user_agent)s", "protocol": "%(_protocol)s"} }'
+    '"logging.googleapis.com/sourceLocation": { %(_source_location_str)s }, '
+    '"httpRequest": { %(_http_request_str)s }'
 )
 
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -94,9 +94,6 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
-        # self.assertEqual(http_request["referer"], expected_referrer)
-        # self.assertEqual(http_request["remoteIp"], expected_ip)
-        # self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -191,9 +188,6 @@ class Test_get_request_data_from_django(unittest.TestCase):
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
-        # self.assertEqual(http_request["referer"], expected_referrer)
-        # self.assertEqual(http_request["remoteIp"], "127.0.0.1")
-        # self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -207,7 +201,6 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, *_ = self._call_fut()
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
-        # self.assertEqual(http_request["remoteIp"], "127.0.0.1")
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -94,9 +94,9 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
-        self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remoteIp"], expected_ip)
-        self.assertEqual(http_request["requestSize"], len(body_content))
+        # self.assertEqual(http_request["referer"], expected_referrer)
+        # self.assertEqual(http_request["remoteIp"], expected_ip)
+        # self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -191,9 +191,9 @@ class Test_get_request_data_from_django(unittest.TestCase):
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
-        self.assertEqual(http_request["referer"], expected_referrer)
-        self.assertEqual(http_request["remoteIp"], "127.0.0.1")
-        self.assertEqual(http_request["requestSize"], len(body_content))
+        # self.assertEqual(http_request["referer"], expected_referrer)
+        # self.assertEqual(http_request["remoteIp"], "127.0.0.1")
+        # self.assertEqual(http_request["requestSize"], len(body_content))
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
     def test_http_request_sparse(self):
@@ -207,7 +207,7 @@ class Test_get_request_data_from_django(unittest.TestCase):
         http_request, *_ = self._call_fut()
         self.assertEqual(http_request["requestMethod"], "PUT")
         self.assertEqual(http_request["requestUrl"], expected_path)
-        self.assertEqual(http_request["remoteIp"], "127.0.0.1")
+        # self.assertEqual(http_request["remoteIp"], "127.0.0.1")
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -64,7 +64,14 @@ class TestCloudLoggingFilter(unittest.TestCase):
             "function": "test-function",
         }
         record = logging.LogRecord(
-            logname, logging.INFO, expected_location['file'], expected_location['line'], message, None, None, func=expected_location['function']
+            logname,
+            logging.INFO,
+            expected_location["file"],
+            expected_location["line"],
+            message,
+            None,
+            None,
+            func=expected_location["function"],
         )
 
         success = filter_obj.filter(record)
@@ -207,9 +214,13 @@ class TestCloudLoggingFilter(unittest.TestCase):
             self.assertEqual(record._span_id, overwritten_span)
             self.assertEqual(record._span_id_str, overwritten_span)
             self.assertEqual(record._http_request, overwritten_request_object)
-            self.assertEqual(record._http_request_str, json.dumps(overwritten_request_object))
+            self.assertEqual(
+                record._http_request_str, json.dumps(overwritten_request_object)
+            )
             self.assertEqual(record._source_location, overwritten_source_location)
-            self.assertEqual(record._source_location_str, json.dumps(overwritten_source_location))
+            self.assertEqual(
+                record._source_location_str, json.dumps(overwritten_source_location)
+            )
             self.assertEqual(record._resource, overwritten_resource)
 
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -16,6 +16,7 @@ import logging
 import unittest
 from unittest.mock import patch
 import mock
+import json
 
 from google.cloud.logging_v2.handlers._monitored_resources import (
     _FUNCTION_ENV_VARS,
@@ -57,26 +58,31 @@ class TestCloudLoggingFilter(unittest.TestCase):
         filter_obj = self._make_one()
         logname = "loggername"
         message = "hello world，嗨 世界"
-        pathname = "testpath"
-        lineno = 1
-        func = "test-function"
+        expected_location = {
+            "line": 1,
+            "file": "testpath",
+            "function": "test-function",
+        }
         record = logging.LogRecord(
-            logname, logging.INFO, pathname, lineno, message, None, None, func=func
+            logname, logging.INFO, expected_location['file'], expected_location['line'], message, None, None, func=expected_location['function']
         )
 
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.line, lineno)
         self.assertEqual(record.msg, message)
-        self.assertEqual(record.function, func)
-        self.assertEqual(record.file, pathname)
-        self.assertEqual(record.trace, "")
-        self.assertEqual(record.http_request, {})
-        self.assertEqual(record.request_method, "")
-        self.assertEqual(record.request_url, "")
-        self.assertEqual(record.user_agent, "")
-        self.assertEqual(record.protocol, "")
+        self.assertEqual(record._msg_str, message)
+        self.assertEqual(record._source_location, expected_location)
+        self.assertEqual(record._source_location_str, json.dumps(expected_location))
+        self.assertIsNone(record._resource)
+        self.assertIsNone(record._trace)
+        self.assertEqual(record._trace_str, "")
+        self.assertIsNone(record._span_id)
+        self.assertEqual(record._span_id_str, "")
+        self.assertIsNone(record._http_request)
+        self.assertEqual(record._http_request_str, "{}")
+        self.assertIsNone(record._labels)
+        self.assertEqual(record._labels_str, "{}")
 
     def test_minimal_record(self):
         """
@@ -91,16 +97,19 @@ class TestCloudLoggingFilter(unittest.TestCase):
         success = filter_obj.filter(record)
         self.assertTrue(success)
 
-        self.assertEqual(record.line, 0)
-        self.assertEqual(record.msg, "")
-        self.assertEqual(record.function, "")
-        self.assertEqual(record.file, "")
-        self.assertEqual(record.trace, "")
-        self.assertEqual(record.http_request, {})
-        self.assertEqual(record.request_method, "")
-        self.assertEqual(record.request_url, "")
-        self.assertEqual(record.user_agent, "")
-        self.assertEqual(record.protocol, "")
+        self.assertIsNone(record.msg)
+        self.assertEqual(record._msg_str, "")
+        self.assertIsNone(record._source_location)
+        self.assertEqual(record._source_location_str, "{}")
+        self.assertIsNone(record._resource)
+        self.assertIsNone(record._trace)
+        self.assertEqual(record._trace_str, "")
+        self.assertIsNone(record._span_id)
+        self.assertEqual(record._span_id_str, "")
+        self.assertIsNone(record._http_request)
+        self.assertEqual(record._http_request_str, "{}")
+        self.assertIsNone(record._labels)
+        self.assertEqual(record._labels_str, "{}")
 
     def test_record_with_request(self):
         """
@@ -115,6 +124,8 @@ class TestCloudLoggingFilter(unittest.TestCase):
         expected_path = "http://testserver/123"
         expected_agent = "Mozilla/5.0"
         expected_trace = "123"
+        expected_span = "456"
+        combined_trace = f"{expected_trace}/{expected_span}"
         expected_request = {
             "requestMethod": "PUT",
             "requestUrl": expected_path,
@@ -129,19 +140,18 @@ class TestCloudLoggingFilter(unittest.TestCase):
                 data="body",
                 headers={
                     "User-Agent": expected_agent,
-                    "X_CLOUD_TRACE_CONTEXT": expected_trace,
+                    "X_CLOUD_TRACE_CONTEXT": combined_trace,
                 },
             )
             success = filter_obj.filter(record)
             self.assertTrue(success)
 
-            self.assertEqual(record.trace, expected_trace)
-            for key, val in expected_request.items():
-                self.assertEqual(record.http_request[key], val)
-            self.assertEqual(record.request_method, "PUT")
-            self.assertEqual(record.request_url, expected_path)
-            self.assertEqual(record.user_agent, expected_agent)
-            self.assertEqual(record.protocol, "HTTP/1.1")
+            self.assertEqual(record._trace, expected_trace)
+            self.assertEqual(record._trace_str, expected_trace)
+            self.assertEqual(record._span_id, expected_span)
+            self.assertEqual(record._span_id_str, expected_span)
+            self.assertEqual(record._http_request, expected_request)
+            self.assertEqual(record._http_request_str, json.dumps(expected_request))
 
     def test_user_overrides(self):
         """
@@ -163,8 +173,12 @@ class TestCloudLoggingFilter(unittest.TestCase):
                 headers={"User-Agent": "default", "X_CLOUD_TRACE_CONTEXT": "default"},
             )
             # override values
+            overwritten_resource = "test"
+            record.resource = overwritten_resource
             overwritten_trace = "456"
             record.trace = overwritten_trace
+            overwritten_span = "789"
+            record.span_id = overwritten_span
             overwritten_method = "GET"
             overwritten_url = "www.google.com"
             overwritten_agent = "custom"
@@ -188,15 +202,15 @@ class TestCloudLoggingFilter(unittest.TestCase):
             success = filter_obj.filter(record)
             self.assertTrue(success)
 
-            self.assertEqual(record.trace, overwritten_trace)
-            self.assertEqual(record.http_request, overwritten_request_object)
-            self.assertEqual(record.request_method, overwritten_method)
-            self.assertEqual(record.request_url, overwritten_url)
-            self.assertEqual(record.user_agent, overwritten_agent)
-            self.assertEqual(record.protocol, overwritten_protocol)
-            self.assertEqual(record.line, overwritten_line)
-            self.assertEqual(record.function, overwritten_function)
-            self.assertEqual(record.file, overwritten_file)
+            self.assertEqual(record._trace, overwritten_trace)
+            self.assertEqual(record._trace_str, overwritten_trace)
+            self.assertEqual(record._span_id, overwritten_span)
+            self.assertEqual(record._span_id_str, overwritten_span)
+            self.assertEqual(record._http_request, overwritten_request_object)
+            self.assertEqual(record._http_request_str, json.dumps(overwritten_request_object))
+            self.assertEqual(record._source_location, overwritten_source_location)
+            self.assertEqual(record._source_location_str, json.dumps(overwritten_source_location))
+            self.assertEqual(record._resource, overwritten_resource)
 
 
 class TestCloudLoggingHandler(unittest.TestCase):

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -67,15 +67,10 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/spanId": "",
             "logging.googleapis.com/sourceLocation": {
                 "file": pathname,
-                "line": str(lineno),
+                "line": lineno,
                 "function": func,
             },
-            "httpRequest": {
-                "requestMethod": "",
-                "requestUrl": "",
-                "userAgent": "",
-                "protocol": "",
-            },
+            "httpRequest": {},
             "logging.googleapis.com/labels": labels,
         }
         handler.filter(record)
@@ -98,17 +93,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         expected_payload = {
             "message": "",
             "logging.googleapis.com/trace": "",
-            "logging.googleapis.com/sourceLocation": {
-                "file": "",
-                "line": "0",
-                "function": "",
-            },
-            "httpRequest": {
-                "requestMethod": "",
-                "requestUrl": "",
-                "userAgent": "",
-                "protocol": "",
-            },
+            "logging.googleapis.com/sourceLocation": {},
+            "httpRequest": {},
             "logging.googleapis.com/labels": {},
         }
         handler.filter(record)
@@ -192,14 +178,9 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/spanId": overwrite_span,
             "logging.googleapis.com/sourceLocation": {
                 "file": overwrite_file,
-                "function": "",
-                "line": "0",
             },
             "httpRequest": {
-                "requestMethod": "",
                 "requestUrl": overwrite_path,
-                "userAgent": "",
-                "protocol": "",
             },
             "logging.googleapis.com/labels": {
                 "default_key": "default-value",

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -176,12 +176,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         expected_payload = {
             "logging.googleapis.com/trace": overwrite_trace,
             "logging.googleapis.com/spanId": overwrite_span,
-            "logging.googleapis.com/sourceLocation": {
-                "file": overwrite_file,
-            },
-            "httpRequest": {
-                "requestUrl": overwrite_path,
-            },
+            "logging.googleapis.com/sourceLocation": {"file": overwrite_file},
+            "httpRequest": {"requestUrl": overwrite_path},
             "logging.googleapis.com/labels": {
                 "default_key": "default-value",
                 "overwritten_key": "new_value",


### PR DESCRIPTION
Refactor PR in prep for the next minor release

- use `_` naming convention for added LogRecord fields, to prevent accidental user overide and avoid confusion
- create separate guaranteed string representations for all fields (for StructuredLogHandler)
- added helper functions to simplify code
- removed some http_request fields (for now) that aren't fully tested across all environments


fixes https://github.com/googleapis/python-logging/issues/266