### PR TITLE
fix: remove noisy logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ system_tests/local_test_setup
 # Make sure a generated file isn't accidentally committed.
 pylintrc
 pylintrc.test
+
+# ignore owlbot
+owl-bot-staging

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -24,6 +24,7 @@ from google.cloud.logging_v2.handlers._helpers import get_request_data
 
 DEFAULT_LOGGER_NAME = "python"
 
+"""Exclude internal logs from propagating through handlers"""
 EXCLUDED_LOGGER_DEFAULTS = ("google.cloud", "google.auth", "google_auth_httplib2", "google.api_core.bidi", "werkzeug")
 
 _CLEAR_HANDLER_RESOURCE_TYPES = ("gae_app", "cloud_function")
@@ -221,5 +222,6 @@ def setup_logging(
     logger.setLevel(log_level)
     logger.addHandler(handler)
     for logger_name in all_excluded_loggers:
+        # prevent excluded loggers from propagating logs to handler
         logger = logging.getLogger(logger_name)
         logger.propagate = False

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -25,7 +25,13 @@ from google.cloud.logging_v2.handlers._helpers import get_request_data
 DEFAULT_LOGGER_NAME = "python"
 
 """Exclude internal logs from propagating through handlers"""
-EXCLUDED_LOGGER_DEFAULTS = ("google.cloud", "google.auth", "google_auth_httplib2", "google.api_core.bidi", "werkzeug")
+EXCLUDED_LOGGER_DEFAULTS = (
+    "google.cloud",
+    "google.auth",
+    "google_auth_httplib2",
+    "google.api_core.bidi",
+    "werkzeug",
+)
 
 _CLEAR_HANDLER_RESOURCE_TYPES = ("gae_app", "cloud_function")
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -24,7 +24,7 @@ from google.cloud.logging_v2.handlers._helpers import get_request_data
 
 DEFAULT_LOGGER_NAME = "python"
 
-EXCLUDED_LOGGER_DEFAULTS = ("google.cloud", "google.auth", "google_auth_httplib2")
+EXCLUDED_LOGGER_DEFAULTS = ("google.cloud", "google.auth", "google_auth_httplib2", "google.api_core.bidi", "werkzeug")
 
 _CLEAR_HANDLER_RESOURCE_TYPES = ("gae_app", "cloud_function")
 
@@ -223,4 +223,3 @@ def setup_logging(
     for logger_name in all_excluded_loggers:
         logger = logging.getLogger(logger_name)
         logger.propagate = False
-        logger.addHandler(logging.StreamHandler())

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -799,7 +799,13 @@ class TestClient(unittest.TestCase):
         handler.transport.worker.stop()
 
         expected_kwargs = {
-            "excluded_loggers": ("google.cloud", "google.auth", "google_auth_httplib2"),
+            "excluded_loggers": (
+                "google.cloud",
+                "google.auth",
+                "google_auth_httplib2",
+                "google.api_core.bidi",
+                "werkzeug",
+            ),
             "log_level": 20,
         }
         self.assertEqual(kwargs, expected_kwargs)
@@ -836,7 +842,13 @@ class TestClient(unittest.TestCase):
         handler.transport.worker.stop()
 
         expected_kwargs = {
-            "excluded_loggers": ("google.cloud", "google.auth", "google_auth_httplib2"),
+            "excluded_loggers": (
+                "google.cloud",
+                "google.auth",
+                "google_auth_httplib2",
+                "google.api_core.bidi",
+                "werkzeug",
+            ),
             "log_level": 20,
         }
         self.assertEqual(kwargs, expected_kwargs)


### PR DESCRIPTION
- Adds "google.api_core.bidi" and "werkzeug" to the list of excluded logs to fix some noisyness on some environments
- Previously, SteamHandlers were added to excluded loggers by default, so they would still log to standard output. This is leading to noisy logs on environments that send all stdout to Cloud Logging. Instead, users should expect to add handlers manually if desired

Fixes https://github.com/googleapis/python-logging/issues/261