### PR TITLE
fix: changed region format on serverless

### DIFF
--- a/google/cloud/logging_v2/handlers/_monitored_resources.py
+++ b/google/cloud/logging_v2/handlers/_monitored_resources.py
@@ -73,7 +73,7 @@ def _create_functions_resource():
         labels={
             "project_id": project,
             "function_name": function_name,
-            "region": region if region else "",
+            "region": region.split("/")[-1] if region else "",
         },
     )
     return resource
@@ -131,7 +131,7 @@ def _create_cloud_run_resource():
             "project_id": project,
             "service_name": os.environ.get(_CLOUD_RUN_SERVICE_ID, ""),
             "revision_name": os.environ.get(_CLOUD_RUN_REVISION_ID, ""),
-            "location": region if region else "",
+            "location": region.split("/")[-1] if region else "",
             "configuration_name": os.environ.get(_CLOUD_RUN_CONFIGURATION_ID, ""),
         },
     )


### PR DESCRIPTION
Changed the region format for GCF and Cloud Run to use the last path component, instead of the entire path returned from metadataserver ( `us-central1` instead of `projects/xxxxxx/regions/us-central1` )

Fixes https://github.com/googleapis/python-logging/issues/284
