### PR TITLE
fix: improve API compatibility for next release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,3 @@ system_tests/local_test_setup
 # Make sure a generated file isn't accidentally committed.
 pylintrc
 pylintrc.test
-
-# ignore owlbot
-owl-bot-staging

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -68,7 +68,10 @@ def get_request_data_from_flask():
     http_request = {
         "requestMethod": flask.request.method,
         "requestUrl": flask.request.url,
+        "requestSize": flask.request.content_length,
         "userAgent": flask.request.user_agent.string,
+        "remoteIp": flask.request.remote_addr,
+        "referer": flask.request.referrer,
         "protocol": flask.request.environ.get(_PROTOCOL_HEADER),
     }
 
@@ -97,7 +100,10 @@ def get_request_data_from_django():
     http_request = {
         "requestMethod": request.method,
         "requestUrl": request.build_absolute_uri(),
+        "requestSize": content_length,
         "userAgent": request.META.get(_DJANGO_USERAGENT_HEADER),
+        "remoteIp": request.META.get(_DJANGO_REMOTE_ADDR_HEADER),
+        "referer": request.META.get(_DJANGO_REFERER_HEADER),
         "protocol": request.META.get(_PROTOCOL_HEADER),
     }
 

--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -96,6 +96,13 @@ def get_request_data_from_django():
     if request is None:
         return None, None, None
 
+    # convert content_length to int if it exists
+    content_length = None
+    try:
+        content_length = int(request.META.get(_DJANGO_CONTENT_LENGTH))
+    except (ValueError, TypeError):
+        content_length = None
+
     # build http_request
     http_request = {
         "requestMethod": request.method,

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -93,7 +93,7 @@ class CloudLoggingFilter(logging.Filter):
         record._source_location_str = json.dumps(record._source_location or {})
         record._labels_str = json.dumps(record._labels or {})
         # break quotes for parsing through structured logging
-        record._msg_str = record.msg.replace('"', '\\"') or ""
+        record._msg_str = str(record.msg).replace('"', '\\"') if record.msg else ""
         return True
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -40,7 +40,7 @@ class CloudLoggingFilter(logging.Filter):
 
     # The subset of http_request fields have been tested to work consistently across GCP environments
     # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest
-    _supported_http_fields = ("requestMethod", "requestUrl", "requestSize", "userAgent", "protocol")
+    _supported_http_fields = ("requestMethod", "requestUrl", "userAgent", "protocol")
 
     def __init__(self, project=None, default_labels=None):
         self.project = project

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -75,7 +75,11 @@ class CloudLoggingFilter(logging.Filter):
         inferred_http, inferred_trace, inferred_span = get_request_data()
         if inferred_http is not None:
             # filter inferred_http to include only well-supported fields
-            inferred_http = {k:v for (k,v) in inferred_http.items() if k in self._supported_http_fields and v is not None}
+            inferred_http = {
+                k: v
+                for (k, v) in inferred_http.items()
+                if k in self._supported_http_fields and v is not None
+            }
         if inferred_trace is not None and self.project is not None:
             # add full path for detected trace
             inferred_trace = f"projects/{self.project}/traces/{inferred_trace}"

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -38,6 +38,10 @@ class CloudLoggingFilter(logging.Filter):
     overwritten using the `extras` argument when writing logs.
     """
 
+    # The subset of http_request fields have been tested to work consistently across GCP environments
+    # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest
+    _supported_http_fields = ("requestMethod", "requestUrl", "requestSize", "userAgent", "protocol")
+
     def __init__(self, project=None, default_labels=None):
         self.project = project
         self.default_labels = default_labels if default_labels else {}
@@ -67,8 +71,13 @@ class CloudLoggingFilter(logging.Filter):
         Add new Cloud Logging data to each LogRecord as it comes in
         """
         user_labels = getattr(record, "labels", {})
+        # infer request data from the environment
         inferred_http, inferred_trace, inferred_span = get_request_data()
+        if inferred_http is not None:
+            # filter inferred_http to include only well-supported fields
+            inferred_http = {k:v for (k,v) in inferred_http.items() if k in self._supported_http_fields and v is not None}
         if inferred_trace is not None and self.project is not None:
+            # add full path for detected trace
             inferred_trace = f"projects/{self.project}/traces/{inferred_trace}"
         # set new record values
         record._resource = getattr(record, "resource", None)
@@ -77,13 +86,14 @@ class CloudLoggingFilter(logging.Filter):
         record._http_request = getattr(record, "http_request", inferred_http)
         record._source_location = CloudLoggingFilter._infer_source_location(record)
         record._labels = {**self.default_labels, **user_labels} or None
-        # create guaranteed string representations for structured logging
-        record._msg_str = record.msg or ""
+        # create string representations for structured logging
         record._trace_str = record._trace or ""
         record._span_id_str = record._span_id or ""
         record._http_request_str = json.dumps(record._http_request or {})
         record._source_location_str = json.dumps(record._source_location or {})
         record._labels_str = json.dumps(record._labels or {})
+        # break quotes for parsing through structured logging
+        record._msg_str = record.msg.replace('"', '\\"') or ""
         return True
 
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -75,23 +75,18 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         expected_agent = "Mozilla/5.0"
         expected_referrer = "self"
         expected_ip = "10.1.2.3"
-        body_content = "test"
         headers = {
             "User-Agent": expected_agent,
             "Referer": expected_referrer,
         }
 
         app = self.create_app()
-        with app.test_client() as c:
-            c.put(
-                path=expected_path,
-                data=body_content,
-                environ_base={"REMOTE_ADDR": expected_ip},
+        with app.test_request_context(expected_path,
                 headers=headers,
-            )
+                environ_base={"REMOTE_ADDR": expected_ip}):
             http_request, *_ = self._call_fut()
 
-        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestMethod"], "GET")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["userAgent"], expected_agent)
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
@@ -99,10 +94,9 @@ class Test_get_request_data_from_flask(unittest.TestCase):
     def test_http_request_sparse(self):
         expected_path = "http://testserver/123"
         app = self.create_app()
-        with app.test_client() as c:
-            c.put(path=expected_path)
+        with app.test_request_context(expected_path):
             http_request, *_ = self._call_fut()
-        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertEqual(http_request["requestMethod"], "GET")
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -81,9 +81,9 @@ class Test_get_request_data_from_flask(unittest.TestCase):
         }
 
         app = self.create_app()
-        with app.test_request_context(expected_path,
-                headers=headers,
-                environ_base={"REMOTE_ADDR": expected_ip}):
+        with app.test_request_context(
+            expected_path, headers=headers, environ_base={"REMOTE_ADDR": expected_ip}
+        ):
             http_request, *_ = self._call_fut()
 
         self.assertEqual(http_request["requestMethod"], "GET")

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -141,8 +141,13 @@ class TestCloudLoggingFilter(unittest.TestCase):
         }
 
         app = self.create_app()
-        with app.test_request_context(expected_path,
-                headers={"User-Agent": expected_agent, "X_CLOUD_TRACE_CONTEXT": combined_trace}):
+        with app.test_request_context(
+            expected_path,
+            headers={
+                "User-Agent": expected_agent,
+                "X_CLOUD_TRACE_CONTEXT": combined_trace,
+            },
+        ):
             success = filter_obj.filter(record)
             self.assertTrue(success)
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -134,22 +134,15 @@ class TestCloudLoggingFilter(unittest.TestCase):
         expected_span = "456"
         combined_trace = f"{expected_trace}/{expected_span}"
         expected_request = {
-            "requestMethod": "PUT",
+            "requestMethod": "GET",
             "requestUrl": expected_path,
             "userAgent": expected_agent,
             "protocol": "HTTP/1.1",
         }
 
         app = self.create_app()
-        with app.test_client() as c:
-            c.put(
-                path=expected_path,
-                data="body",
-                headers={
-                    "User-Agent": expected_agent,
-                    "X_CLOUD_TRACE_CONTEXT": combined_trace,
-                },
-            )
+        with app.test_request_context(expected_path,
+                headers={"User-Agent": expected_agent, "X_CLOUD_TRACE_CONTEXT": combined_trace}):
             success = filter_obj.filter(record)
             self.assertTrue(success)
 

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -106,7 +106,7 @@ class TestStructuredLogHandler(unittest.TestCase):
 
     def test_format_with_quotes(self):
         """
-        When logging a message containing quotes, escape chars (\) should be added
+        When logging a message containing quotes, escape chars should be added
         """
         import logging
         import json
@@ -116,13 +116,6 @@ class TestStructuredLogHandler(unittest.TestCase):
         expected_result = '\\"test\\"'
         record = logging.LogRecord(None, logging.INFO, None, None, message, None, None,)
         record.created = None
-        expected_payload = {
-            "message": "",
-            "logging.googleapis.com/trace": "",
-            "logging.googleapis.com/sourceLocation": {},
-            "httpRequest": {},
-            "logging.googleapis.com/labels": {},
-        }
         handler.filter(record)
         result = json.loads(handler.format(record))
         result["message"] = expected_result

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -145,7 +145,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/trace": expected_trace,
             "logging.googleapis.com/spanId": expected_span,
             "httpRequest": {
-                "requestMethod": "PUT",
+                "requestMethod": "GET",
                 "requestUrl": expected_path,
                 "userAgent": expected_agent,
                 "protocol": "HTTP/1.1",
@@ -153,15 +153,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         }
 
         app = self.create_app()
-        with app.test_client() as c:
-            c.put(
-                path=expected_path,
-                data="body",
-                headers={
-                    "User-Agent": expected_agent,
-                    "X_CLOUD_TRACE_CONTEXT": trace_header,
-                },
-            )
+        with app.test_request_context(expected_path,
+                headers={"User-Agent": expected_agent, "X_CLOUD_TRACE_CONTEXT": trace_header}):
             handler.filter(record)
             result = json.loads(handler.format(record))
             for (key, value) in expected_payload.items():

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -104,6 +104,30 @@ class TestStructuredLogHandler(unittest.TestCase):
                 value, result[key], f"expected_payload[{key}] != result[{key}]"
             )
 
+    def test_format_with_quotes(self):
+        """
+        When logging a message containing quotes, escape chars (\) should be added
+        """
+        import logging
+        import json
+
+        handler = self._make_one()
+        message = '"test"'
+        expected_result = '\\"test\\"'
+        record = logging.LogRecord(None, logging.INFO, None, None, message, None, None,)
+        record.created = None
+        expected_payload = {
+            "message": "",
+            "logging.googleapis.com/trace": "",
+            "logging.googleapis.com/sourceLocation": {},
+            "httpRequest": {},
+            "logging.googleapis.com/labels": {},
+        }
+        handler.filter(record)
+        result = json.loads(handler.format(record))
+        result['message'] = expected_result
+        self.assertEqual(result['message'], expected_result)
+
     def test_format_with_request(self):
         import logging
         import json

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -125,8 +125,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
-        result['message'] = expected_result
-        self.assertEqual(result['message'], expected_result)
+        result["message"] = expected_result
+        self.assertEqual(result["message"], expected_result)
 
     def test_format_with_request(self):
         import logging
@@ -153,8 +153,13 @@ class TestStructuredLogHandler(unittest.TestCase):
         }
 
         app = self.create_app()
-        with app.test_request_context(expected_path,
-                headers={"User-Agent": expected_agent, "X_CLOUD_TRACE_CONTEXT": trace_header}):
+        with app.test_request_context(
+            expected_path,
+            headers={
+                "User-Agent": expected_agent,
+                "X_CLOUD_TRACE_CONTEXT": trace_header,
+            },
+        ):
             handler.filter(record)
             result = json.loads(handler.format(record))
             for (key, value) in expected_payload.items():


### PR DESCRIPTION
- As aprt of the next release, I removed some fields in the http_request data (referer, remoteIp, requestSize), because they don't work consistently across all GCP environments yet. I realized this would be considered a breaking change for AppEngine users who may already be relying on these fields. Instead of removing the fields, non-appengine handlers now filter them out. We can re-consider the future of these fields for v3.0.0
- StructuredLogHandler formatting breaks if users log text with quotes in it. Now, the handler will add "\" before each quote found in the message string
- The Flask request detection broke in the unit tests, so I also fixed that