### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "proto-plus >= 1.11.0",
+    "packaging >= 14.3"
 ]
 extras = {}
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "proto-plus >= 1.11.0",
-    "packaging >= 14.3"
+    "packaging >= 14.3",
 ]
 extras = {}
 

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,3 +8,4 @@
 google-api-core==1.22.2
 google-cloud-core==1.4.1
 proto-plus==1.11.0
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3