### PR TITLE
feat!: support string-encoded json

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -218,18 +218,19 @@ def _format_and_parse_message(record, formatter_handler):
         record (logging.LogRecord): The record object representing the log
         formatter_handler (logging.Handler): The handler used to format the log
     """
-    message = record.msg
-    if isinstance(message, str):
-        # format message string based on superclass
-        message = formatter_handler.format(record)
-        try:
-            # attempt to parse encoded json into dictionary
-            if message[0] == '{':
-                json_message = json.loads(message)
-                if isinstance(json_message, collections.abc.Mapping):
-                    message = json_message
-        except (json.decoder.JSONDecodeError, IndexError):
-            pass
+    # if message is a dictionary, return as-is
+    if isinstance(record.msg, collections.abc.Mapping):
+        return record.msg
+    # format message string based on superclass
+    message = formatter_handler.format(record)
+    try:
+        # attempt to parse encoded json into dictionary
+        if message[0] == '{':
+            json_message = json.loads(message)
+            if isinstance(json_message, collections.abc.Mapping):
+                message = json_message
+    except (json.decoder.JSONDecodeError, IndexError):
+        pass
     return message
 
 

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -215,6 +215,8 @@ def _format_and_parse_message(record, formatter_handler):
     Helper function to apply formatting to a LogRecord message,
     and attempt to parse encoded JSON into a dictionary object.
 
+    Resulting output will be of type (str | dict | None)
+
     Args:
         record (logging.LogRecord): The record object representing the log
         formatter_handler (logging.Handler): The handler used to format the log

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -230,8 +230,10 @@ def _format_and_parse_message(record, formatter_handler):
             if isinstance(json_message, collections.abc.Mapping):
                 message = json_message
     except (json.decoder.JSONDecodeError, IndexError):
+        # log string is not valid json
         pass
-    return message
+    # if formatted message contains no content, return None
+    return message if message != "None" else None
 
 
 def setup_logging(

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -209,6 +209,7 @@ class CloudLoggingHandler(logging.StreamHandler):
             source_location=record._source_location,
         )
 
+
 def _format_and_parse_message(record, formatter_handler):
     """
     Helper function to apply formatting to a LogRecord message,
@@ -225,7 +226,7 @@ def _format_and_parse_message(record, formatter_handler):
     message = formatter_handler.format(record)
     try:
         # attempt to parse encoded json into dictionary
-        if message[0] == '{':
+        if message[0] == "{":
             json_message = json.loads(message)
             if isinstance(json_message, collections.abc.Mapping):
                 message = json_message

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -19,6 +19,7 @@ import json
 import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
+from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
 
 GCP_FORMAT = (
     "{%(_payload_str)s"
@@ -62,22 +63,7 @@ class StructuredLogHandler(logging.StreamHandler):
             str: A JSON string formatted for GCP structured logging.
         """
         payload = None
-
-
-        if isinstance(record.msg, str):
-            # format message string based on superclass
-            parsed_message = super(StructuredLogHandler, self).format(record)
-            try:
-                if message[0] = '{':
-                    # attempt to parse encoded json into dictionary
-                    json_message = json.loads(message)
-                    if isinstance(json_message, collections.abc.Mapping):
-                        parsed_message = json_message
-            except (json.decoder.JSONDecodeError, IndexError):
-                pass
-        else:
-            # if non-string, pass along as-is
-            parsed_message = record.msg
+        message = _format_and_parse_message(record, super(StructuredLogHandler, self))
 
         if isinstance(message, collections.abc.Mapping):
             # if input is a dictionary, encode it as a json string

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -311,6 +311,31 @@ class TestCloudLoggingHandler(unittest.TestCase):
             ),
         )
 
+    def test_emit_minimal(self):
+        from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
+
+        client = _Client(self.PROJECT)
+        handler = self._make_one(
+            client, transport=_Transport, resource=_GLOBAL_RESOURCE
+        )
+        record = logging.LogRecord(
+            None, logging.INFO, None, None, None, None, None
+        )
+        handler.handle(record)
+        self.assertEqual(
+            handler.transport.send_called_with,
+            (
+                record,
+                None,
+                _GLOBAL_RESOURCE,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+
     def test_emit_manual_field_override(self):
         from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
         from google.cloud.logging_v2.resource import Resource

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -449,7 +449,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         expected_result = {"x": logname}
         expected_label = {"python_logger": logname}
         record = logging.LogRecord(
-            logname, logging.INFO, None, None, "", None, None
+            logname, logging.INFO, None, None, None, None, None
         )
         handler.handle(record)
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -401,9 +401,41 @@ class TestCloudLoggingHandler(unittest.TestCase):
             ),
         )
 
+    def test_emit_dict(self):
+        """
+        Handler should support logging dictionaries
+        """
+        from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
+
+        client = _Client(self.PROJECT)
+        handler = self._make_one(
+            client, transport=_Transport, resource=_GLOBAL_RESOURCE,
+        )
+        message = {"x": "test"}
+        logname = "logname"
+        expected_label = {"python_logger": logname}
+        record = logging.LogRecord(
+            logname, logging.INFO, None, None, message, None, None
+        )
+        handler.handle(record)
+
+        self.assertEqual(
+            handler.transport.send_called_with,
+            (
+                record,
+                message,
+                _GLOBAL_RESOURCE,
+                expected_label,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+
     def test_emit_with_encoded_json(self):
         """
-        Handler should respect custom formatters attached
+        Handler should parse json encoded as a string
         """
         from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -318,22 +318,11 @@ class TestCloudLoggingHandler(unittest.TestCase):
         handler = self._make_one(
             client, transport=_Transport, resource=_GLOBAL_RESOURCE
         )
-        record = logging.LogRecord(
-            None, logging.INFO, None, None, None, None, None
-        )
+        record = logging.LogRecord(None, logging.INFO, None, None, None, None, None)
         handler.handle(record)
         self.assertEqual(
             handler.transport.send_called_with,
-            (
-                record,
-                None,
-                _GLOBAL_RESOURCE,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ),
+            (record, None, _GLOBAL_RESOURCE, None, None, None, None, None,),
         )
 
     def test_emit_manual_field_override(self):
@@ -473,9 +462,7 @@ class TestCloudLoggingHandler(unittest.TestCase):
         logname = "logname"
         expected_result = {"x": logname}
         expected_label = {"python_logger": logname}
-        record = logging.LogRecord(
-            logname, logging.INFO, None, None, None, None, None
-        )
+        record = logging.LogRecord(logname, logging.INFO, None, None, None, None, None)
         handler.handle(record)
 
         self.assertEqual(
@@ -516,19 +503,16 @@ class TestCloudLoggingHandler(unittest.TestCase):
         )
 
 
-
 class TestFormatAndParseMessage(unittest.TestCase):
-
     def test_none(self):
         """
-        None messages with no special formatting should return 
+        None messages with no special formatting should return
         None after formatting
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = None
-        record = logging.LogRecord(
-            None, None, None, None, message, None, None
-        )
+        record = logging.LogRecord(None, None, None, None, message, None, None)
         handler = logging.StreamHandler()
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, None)
@@ -538,12 +522,11 @@ class TestFormatAndParseMessage(unittest.TestCase):
         None messages with formatting rules should return formatted string
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = None
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
-        formatter = logging.Formatter('name: %(name)s')
+        formatter = logging.Formatter("name: %(name)s")
         handler.setFormatter(formatter)
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, "name: logname")
@@ -553,10 +536,9 @@ class TestFormatAndParseMessage(unittest.TestCase):
         Unformated strings should be returned unchanged
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = '"test"'
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, message)
@@ -566,10 +548,9 @@ class TestFormatAndParseMessage(unittest.TestCase):
         Empty strings should be returned unchanged
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = ""
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, message)
@@ -579,13 +560,12 @@ class TestFormatAndParseMessage(unittest.TestCase):
         string messages should properly apply formatting and arguments
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = "argument: %s"
         arg = "test"
-        record = logging.LogRecord(
-            "logname", None, None, None, message, arg, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, arg, None)
         handler = logging.StreamHandler()
-        formatter = logging.Formatter('name: %(name)s :: message: %(message)s')
+        formatter = logging.Formatter("name: %(name)s :: message: %(message)s")
         handler.setFormatter(formatter)
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, "name: logname :: message: argument: test")
@@ -595,12 +575,11 @@ class TestFormatAndParseMessage(unittest.TestCase):
         dict messages should be unchanged
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = {"a": "b"}
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
-        formatter = logging.Formatter('name: %(name)s')
+        formatter = logging.Formatter("name: %(name)s")
         handler.setFormatter(formatter)
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, message)
@@ -610,23 +589,21 @@ class TestFormatAndParseMessage(unittest.TestCase):
         dicts should be extracted from string messages
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = '{ "x": { "y" : "z"  } }'
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
         result = _format_and_parse_message(record, handler)
-        self.assertEqual(result, {"x":{"y":"z"}})
+        self.assertEqual(result, {"x": {"y": "z"}})
 
     def test_broken_encoded_dict(self):
         """
         unparseable encoded dicts should be kept as strings
         """
         from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
         message = '{ "x": { "y" : '
-        record = logging.LogRecord(
-            "logname", None, None, None, message, None, None
-        )
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
         handler = logging.StreamHandler()
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, message)

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -401,6 +401,40 @@ class TestCloudLoggingHandler(unittest.TestCase):
             ),
         )
 
+    def test_emit_with_encoded_json(self):
+        """
+        Handler should respect custom formatters attached
+        """
+        from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
+
+        client = _Client(self.PROJECT)
+        handler = self._make_one(
+            client, transport=_Transport, resource=_GLOBAL_RESOURCE,
+        )
+        logFormatter = logging.Formatter(fmt='{ "x" : "%(name)s" }')
+        handler.setFormatter(logFormatter)
+        logname = "logname"
+        expected_result = {"x": logname}
+        expected_label = {"python_logger": logname}
+        record = logging.LogRecord(
+            logname, logging.INFO, None, None, "", None, None
+        )
+        handler.handle(record)
+
+        self.assertEqual(
+            handler.transport.send_called_with,
+            (
+                record,
+                expected_result,
+                _GLOBAL_RESOURCE,
+                expected_label,
+                None,
+                None,
+                None,
+                None,
+            ),
+        )
+
     def test_format_with_arguments(self):
         """
         Handler should support format string arguments

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -181,10 +181,9 @@ class TestStructuredLogHandler(unittest.TestCase):
         handler = self._make_one()
         logFormatter = logging.Formatter(fmt='{ "name" : "%(name)s" }')
         handler.setFormatter(logFormatter)
-        message = ""
         expected_result = '"name": "logname"'
         record = logging.LogRecord(
-            "logname", logging.INFO, None, None, message, None, None,
+            "logname", logging.INFO, None, None, None, None, None,
         )
         record.created = None
         handler.filter(record)

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -92,13 +92,16 @@ class TestStructuredLogHandler(unittest.TestCase):
         record = logging.LogRecord(None, logging.INFO, None, None, None, None, None,)
         record.created = None
         expected_payload = {
+            "severity": "INFO",
             "logging.googleapis.com/trace": "",
+            "logging.googleapis.com/spanId": "",
             "logging.googleapis.com/sourceLocation": {},
             "httpRequest": {},
             "logging.googleapis.com/labels": {},
         }
         handler.filter(record)
         result = json.loads(handler.format(record))
+        self.assertEqual(set(expected_payload.keys()), set(result.keys()))
         for (key, value) in expected_payload.items():
             self.assertEqual(
                 value, result[key], f"expected_payload[{key}] != result[{key}]"

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -152,6 +152,27 @@ class TestStructuredLogHandler(unittest.TestCase):
         handler.filter(record)
         result = handler.format(record)
         self.assertIn(expected_result, result)
+        self.assertIn("message", result)
+
+    def test_encoded_json(self):
+        """
+        Handler should parse json encoded as a string
+        """
+        import logging
+
+        handler = self._make_one()
+        logFormatter = logging.Formatter(fmt='{ "name" : "%(name)s" }')
+        handler.setFormatter(logFormatter)
+        message = ""
+        expected_result = '"name": "logname"'
+        record = logging.LogRecord(
+            "logname", logging.INFO, None, None, message, None, None,
+        )
+        record.created = None
+        handler.filter(record)
+        result = handler.format(record)
+        self.assertIn(expected_result, result)
+        self.assertNotIn("message", result)
 
     def test_format_with_arguments(self):
         """

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -154,6 +154,24 @@ class TestStructuredLogHandler(unittest.TestCase):
         self.assertIn(expected_result, result)
         self.assertIn("message", result)
 
+    def test_dict(self):
+        """
+        Handler should parse json encoded as a string
+        """
+        import logging
+
+        handler = self._make_one()
+        message = {"x": "test"}
+        expected_result = '"x": "test"'
+        record = logging.LogRecord(
+            "logname", logging.INFO, None, None, message, None, None,
+        )
+        record.created = None
+        handler.filter(record)
+        result = handler.format(record)
+        self.assertIn(expected_result, result)
+        self.assertNotIn("message", result)
+
     def test_encoded_json(self):
         """
         Handler should parse json encoded as a string


### PR DESCRIPTION
We recently merged a PR into the v3.0.0 staging branch adding support for logging dicts as jsonPayload logs in our custom handlers:

```
logging.error({'a':'b'})
↓
{"a" : "b"}
```

While this can be useful in basic logging set-ups, [the Python logging API expects string-like msg inputs](https://docs.python.org/3/library/logging.html#logging.Logger.debug), so this can't always be relied on to work properly in more complex logging environments.

With this PR, the handlers will also attempt to parse a dictionary out of the final log string before sending it on Cloud Logging, so string-encoded dictionaries will work as expected:

```
logging.error('{"a": "b"}') 
↓
{"a" : "b"}
```

This also allows you to set a formatter object with [logging attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) once, and then continue to log strings as normal. Each log will now show up in jsonPayload format in CloudLogging

```
formatter = logging.Formatter(fmt='{"thread": "%(threadName)s", "message": "%(msg)s", "hardcoded": "test" }')
handler.setFormatter(logFormatter)
logging.error("hello")
↓
{"message": "hello", "thread": "MainThread", "hardcoded": "test" }
```

You can also specify in custom fields using the `extra` argument:

```
formatter = logging.Formatter(fmt='{"message": "%(msg)s", "custom": "%(custom_arg)s" }')
handler.setFormatter(logFormatter)
logging.error("hello", extra={"custom_arg":"test"})
↓
{"message": "hello", "custom": "test" }
```

Fixes https://github.com/googleapis/python-logging/issues/331