### PR TITLE
fix!: api consistency between HTTP and Gapic layers

### DIFF
--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -100,7 +100,7 @@ class _LoggingAPI(object):
         loggers = {}
 
         if max_results is not None and max_results < 0:
-            raise ValueError('max_results must be positive')
+            raise ValueError("max_results must be positive")
 
         # create generator
         def log_entries_pager(log_iter):
@@ -217,7 +217,7 @@ class _SinksAPI(object):
         sink_iter = iter(response)
 
         if max_results is not None and max_results < 0:
-            raise ValueError('max_results must be positive')
+            raise ValueError("max_results must be positive")
 
         def sinks_pager(sink_iter):
             i = 0
@@ -395,7 +395,7 @@ class _MetricsAPI(object):
         metric_iter = iter(response)
 
         if max_results is not None and max_results < 0:
-            raise ValueError('max_results must be positive')
+            raise ValueError("max_results must be positive")
 
         def metrics_pager(metric_iter):
             i = 0

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -49,8 +49,7 @@ class _LoggingAPI(object):
         *,
         filter_=None,
         order_by=None,
-        page_size=None,
-        page_token=None,
+        max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -69,11 +68,6 @@ class _LoggingAPI(object):
                 https://cloud.google.com/logging/docs/view/advanced_filters
             order_by (str) One of :data:`~logging_v2.ASCENDING`
                 or :data:`~logging_v2.DESCENDING`.
-            page_size (int): maximum number of entries to return, If not passed,
-                defaults to a value set by the API.
-            page_token (str): opaque marker for the next "page" of entries. If not
-                passed, the API will return the first page of
-                entries.
 
         Returns:
             Iterator[~logging_v2.LogEntry]
@@ -84,8 +78,7 @@ class _LoggingAPI(object):
             resource_names=resource_names,
             filter=filter_,
             order_by=order_by,
-            page_size=page_size,
-            page_token=page_token,
+            page_size=None,
         )
 
         response = self._gapic_api.list_log_entries(request=request)
@@ -97,9 +90,13 @@ class _LoggingAPI(object):
         loggers = {}
 
         def log_entries_pager(page_iter):
+            i = 0
             for page in page_iter:
+                if max_results is not None and i >= max_results:
+                    break
                 log_entry_dict = _parse_log_entry(LogEntryPB.pb(page))
                 yield entry_from_resource(log_entry_dict, self._client, loggers=loggers)
+                i += 1
 
         return log_entries_pager(page_iter)
 

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -44,12 +44,7 @@ class _LoggingAPI(object):
         self._client = client
 
     def list_entries(
-        self,
-        resource_names,
-        *,
-        filter_=None,
-        order_by=None,
-        max_results=None,
+        self, resource_names, *, filter_=None, order_by=None, max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -206,6 +201,7 @@ class _SinksAPI(object):
                 # Convert the GAPIC sink type into the handwritten `Sink` type
                 yield Sink.from_api_repr(LogSink.to_dict(page), client=self._client)
                 i += 1
+
         return sinks_pager(page_iter)
 
     def sink_create(

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -356,7 +356,7 @@ class _MetricsAPI(object):
         """
         path = f"projects/{project}"
         request = ListLogMetricsRequest(
-            parent=path, page_size=page_size, page_token=page_token,
+                parent=path, page_size=max_results,
         )
         response = self._gapic_api.list_log_metrics(request=request)
         page_iter = iter(response)

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -387,7 +387,7 @@ class _MetricsAPI(object):
                 passed, the API will return the first page of entries.
 
         Returns:
-            Iterable[logging_v2.Metric]: Iterable of metrics.
+            Generator[logging_v2.Metric]
         """
         path = f"projects/{project}"
         request = ListLogMetricsRequest(

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -99,9 +99,8 @@ class _LoggingAPI(object):
         # re-used by other log entries from the same logger.
         loggers = {}
 
-        if max_results is not None:
-            # drop negative values
-            max_results = max(max_results, 0)
+        if max_results is not None and max_results < 0:
+            raise ValueError('max_results must be positive')
 
         # create generator
         def log_entries_pager(log_iter):
@@ -217,9 +216,8 @@ class _SinksAPI(object):
         response = self._gapic_api.list_sinks(request)
         sink_iter = iter(response)
 
-        if max_results is not None:
-            # drop negative values
-            max_results = max(max_results, 0)
+        if max_results is not None and max_results < 0:
+            raise ValueError('max_results must be positive')
 
         def sinks_pager(sink_iter):
             i = 0
@@ -396,9 +394,8 @@ class _MetricsAPI(object):
         response = self._gapic_api.list_log_metrics(request=request)
         metric_iter = iter(response)
 
-        if max_results is not None:
-            # drop negative values
-            max_results = max(max_results, 0)
+        if max_results is not None and max_results < 0:
+            raise ValueError('max_results must be positive')
 
         def metrics_pager(metric_iter):
             i = 0

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -484,7 +484,7 @@ class _MetricsAPI(object):
 
 def _entries_pager(page_iter, max_results=None):
     if max_results is not None and max_results < 0:
-        raise ValueError('max_results must be positive')
+        raise ValueError("max_results must be positive")
 
     i = 0
     for page in page_iter:

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -69,12 +69,7 @@ class _LoggingAPI(object):
         self.api_request = client._connection.api_request
 
     def list_entries(
-        self,
-        resource_names,
-        *,
-        filter_=None,
-        order_by=None,
-        max_results=None,
+        self, resource_names, *, filter_=None, order_by=None, max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -241,7 +236,7 @@ class _SinksAPI(object):
             extra_params["pageSize"] = max_results
 
         path = f"/{parent}/sinks"
-        iterator =  page_iterator.HTTPIterator(
+        iterator = page_iterator.HTTPIterator(
             client=self._client,
             api_request=self._client._connection.api_request,
             path=path,
@@ -251,7 +246,6 @@ class _SinksAPI(object):
         )
 
         return _entries_pager(iterator, max_results)
-
 
     def sink_create(
         self, parent, sink_name, filter_, destination, *, unique_writer_identity=False
@@ -387,7 +381,7 @@ class _MetricsAPI(object):
             extra_params["pageSize"] = max_results
 
         path = f"/projects/{project}/metrics"
-        iterator =  page_iterator.HTTPIterator(
+        iterator = page_iterator.HTTPIterator(
             client=self._client,
             api_request=self._client._connection.api_request,
             path=path,
@@ -396,7 +390,6 @@ class _MetricsAPI(object):
             extra_params=extra_params,
         )
         return _entries_pager(iterator, max_results)
-
 
     def metric_create(self, project, metric_name, filter_, description):
         """Create a metric resource.
@@ -458,6 +451,7 @@ class _MetricsAPI(object):
         target = f"/projects/{project}/metrics/{metric_name}"
         self.api_request(method="DELETE", path=target)
 
+
 def _entries_pager(page_iter, limit):
     i = 0
     for page in page_iter:
@@ -465,6 +459,7 @@ def _entries_pager(page_iter, limit):
             break
         yield page
         i += 1
+
 
 def _item_to_entry(iterator, resource, loggers):
     """Convert a log entry resource to the native object.

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -482,13 +482,13 @@ class _MetricsAPI(object):
         self.api_request(method="DELETE", path=target)
 
 
-def _entries_pager(page_iter, limit):
-    if limit is not None:
-        # drop negative values
-        limit = max(limit, 0)
+def _entries_pager(page_iter, max_results=None):
+    if max_results is not None and max_results < 0:
+        raise ValueError('max_results must be positive')
+
     i = 0
     for page in page_iter:
-        if limit is not None and i >= limit:
+        if max_results is not None and i >= max_results:
             break
         yield page
         i += 1

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -131,7 +131,12 @@ class _LoggingAPI(object):
         )
         # This method uses POST to make a read-only request.
         iterator._HTTP_METHOD = "POST"
-        return iterator
+
+        def log_entries_pager(page_iter):
+            for page in page_iter:
+                yield page
+
+        return log_entries_pager(iterator)
 
     def write_entries(
         self,

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -74,8 +74,7 @@ class _LoggingAPI(object):
         *,
         filter_=None,
         order_by=None,
-        page_size=None,
-        page_token=None,
+        max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -94,11 +93,6 @@ class _LoggingAPI(object):
                 https://cloud.google.com/logging/docs/view/advanced_filters
             order_by (str) One of :data:`~logging_v2.ASCENDING`
                 or :data:`~logging_v2.DESCENDING`.
-            page_size (int): maximum number of entries to return, If not passed,
-                defaults to a value set by the API.
-            page_token (str): opaque marker for the next "page" of entries. If not
-                passed, the API will return the first page of
-                entries.
 
         Returns:
             Iterator[~logging_v2.LogEntry]
@@ -110,9 +104,6 @@ class _LoggingAPI(object):
 
         if order_by is not None:
             extra_params["orderBy"] = order_by
-
-        if page_size is not None:
-            extra_params["pageSize"] = page_size
 
         path = "/entries:list"
         # We attach a mutable loggers dictionary so that as Logger
@@ -126,15 +117,18 @@ class _LoggingAPI(object):
             path=path,
             item_to_value=item_to_value,
             items_key="entries",
-            page_token=page_token,
             extra_params=extra_params,
         )
         # This method uses POST to make a read-only request.
         iterator._HTTP_METHOD = "POST"
 
         def log_entries_pager(page_iter):
+            i = 0
             for page in page_iter:
+                if max_results is not None and i >= max_results:
+                    break
                 yield page
+                i += 1
 
         return log_entries_pager(iterator)
 

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -401,7 +401,7 @@ class _MetricsAPI(object):
                 passed, the API will return the first page of entries.
 
         Returns:
-            Iterable[logging_v2.Metric]: Iterable of metrics.
+            Generator[logging_v2.Metric]
 
         """
         extra_params = {}

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -299,7 +299,6 @@ class Client(ClientWithProject):
             page_token (str): opaque marker for the starting "page" of entries. If not
                 passed, the API will return the first page of entries.
 
-
         Returns:
             Generator[~logging_v2.Sink]
         """
@@ -347,7 +346,7 @@ class Client(ClientWithProject):
                 passed, the API will return the first page of entries.
 
         Returns:
-            Generator[logging_v2.Metric]: Iterable of metrics.
+            Generator[logging_v2.Metric]
         """
         return self.metrics_api.list_metrics(
             self.project,

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -227,8 +227,7 @@ class Client(ClientWithProject):
                 or :data:`~logging_v2.DESCENDING`.
             max_results (Optional[int]):
                 Optional. The maximum number of entries to return.
-                Non-positive values are ignored. Defaults
-                to API unlimited.
+                Non-positive values are ignored. If None, uses API defaults.
 
         Returns:
             Iterator[~logging_v2.LogEntry]
@@ -263,7 +262,7 @@ class Client(ClientWithProject):
         """
         return Sink(name, filter_=filter_, destination=destination, client=self)
 
-    def list_sinks(self, *, parent=None, page_size=None, page_token=None):
+    def list_sinks(self, *, parent=None, max_results=None):
         """List sinks for the a parent resource.
 
         See
@@ -280,14 +279,9 @@ class Client(ClientWithProject):
                     "folders/[FOLDER_ID]".
 
                 If not passed, defaults to the project bound to the API's client.
-            page_size (Optional[int]): The maximum number of sinks in each
-                page of results from this request. Non-positive values are ignored. Defaults to a
-                sensible value set by the API.
-            page_token (Optional[str]): If present, return the next batch of sinks, using the
-                value, which must correspond to the ``nextPageToken`` value
-                returned in the previous response.  Deprecated: use the ``pages``
-                property ofthe returned iterator instead of manually passing the
-                token.
+            max_results (Optional[int]):
+                Optional. The maximum number of entries to return.
+                Non-positive values are ignored. If None, uses API defaults.
 
         Returns:
             Iterator[~logging_v2.sink.Sink]
@@ -295,7 +289,7 @@ class Client(ClientWithProject):
         if parent is None:
             parent = f"projects/{self.project}"
         return self.sinks_api.list_sinks(
-            parent=parent, page_size=page_size, page_token=page_token
+            parent=parent, max_results=max_results,
         )
 
     def metric(self, name, *, filter_=None, description=""):
@@ -316,27 +310,22 @@ class Client(ClientWithProject):
         """
         return Metric(name, filter_=filter_, client=self, description=description)
 
-    def list_metrics(self, *, page_size=None, page_token=None):
+    def list_metrics(self, *, max_results=None):
         """List metrics for the project associated with this client.
 
         See
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics/list
 
         Args:
-            page_size (Optional[int]): The maximum number of sinks in each
-                page of results from this request. Non-positive values are ignored. Defaults to a
-                sensible value set by the API.
-            page_token (Optional[str]): If present, return the next batch of sinks, using the
-                value, which must correspond to the ``nextPageToken`` value
-                returned in the previous response.  Deprecated: use the ``pages``
-                property ofthe returned iterator instead of manually passing the
-                token.
+            max_results (Optional[int]):
+                Optional. The maximum number of entries to return.
+                Non-positive values are ignored. If None, uses API defaults.
 
         Returns:
             Iterator[~logging_v2.metric.Metric]
         """
         return self.metrics_api.list_metrics(
-            self.project, page_size=page_size, page_token=page_token
+            self.project, max_results=max_results
         )
 
     def get_default_handler(self, **kw):

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -204,8 +204,7 @@ class Client(ClientWithProject):
         resource_names=None,
         filter_=None,
         order_by=None,
-        page_size=None,
-        page_token=None,
+        max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -226,11 +225,10 @@ class Client(ClientWithProject):
                 https://cloud.google.com/logging/docs/view/advanced_filters
             order_by (str) One of :data:`~logging_v2.ASCENDING`
                 or :data:`~logging_v2.DESCENDING`.
-            page_size (int): maximum number of entries to return, If not passed,
-                defaults to a value set by the API.
-            page_token (str): opaque marker for the next "page" of entries. If not
-                passed, the API will return the first page of
-                entries.
+            max_results (Optional[int]):
+                Optional. The maximum number of entries to return.
+                Non-positive values are ignored. Defaults
+                to API unlimited.
 
         Returns:
             Iterator[~logging_v2.LogEntry]
@@ -243,8 +241,7 @@ class Client(ClientWithProject):
             resource_names=resource_names,
             filter_=filter_,
             order_by=order_by,
-            page_size=page_size,
-            page_token=page_token,
+            max_results=max_results,
         )
 
     def sink(self, name, *, filter_=None, destination=None):

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -199,12 +199,7 @@ class Client(ClientWithProject):
         return Logger(name, client=self, labels=labels, resource=resource)
 
     def list_entries(
-        self,
-        *,
-        resource_names=None,
-        filter_=None,
-        order_by=None,
-        max_results=None,
+        self, *, resource_names=None, filter_=None, order_by=None, max_results=None,
     ):
         """Return a page of log entry resources.
 
@@ -288,9 +283,7 @@ class Client(ClientWithProject):
         """
         if parent is None:
             parent = f"projects/{self.project}"
-        return self.sinks_api.list_sinks(
-            parent=parent, max_results=max_results,
-        )
+        return self.sinks_api.list_sinks(parent=parent, max_results=max_results,)
 
     def metric(self, name, *, filter_=None, description=""):
         """Creates a metric bound to the current client.
@@ -324,9 +317,7 @@ class Client(ClientWithProject):
         Returns:
             Iterator[~logging_v2.metric.Metric]
         """
-        return self.metrics_api.list_metrics(
-            self.project, max_results=max_results
-        )
+        return self.metrics_api.list_metrics(self.project, max_results=max_results)
 
     def get_default_handler(self, **kw):
         """Return the default logging handler based on the local environment.

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -259,9 +259,16 @@ class Logger(object):
         client.logging_api.logger_delete(logger_name)
 
     def list_entries(
-        self, *, resource_names=None, filter_=None, order_by=None, max_results=None
+        self,
+        *,
+        resource_names=None,
+        filter_=None,
+        order_by=None,
+        max_results=None,
+        page_size=None,
+        page_token=None,
     ):
-        """Return a page of log entries.
+        """Return a generator of log entry resources.
 
         See
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/list
@@ -285,10 +292,14 @@ class Logger(object):
                 or :data:`~logging_v2.DESCENDING`.
             max_results (Optional[int]):
                 Optional. The maximum number of entries to return.
-                Non-positive values are ignored. If None, uses API defaults.
-
+                Non-positive values are treated as 0. If None, uses API defaults.
+            page_size (int): number of entries to fetch in each API call. Although
+                requests are paged internally, logs are returned by the generator
+                one at a time. If not passed, defaults to a value set by the API.
+            page_token (str): opaque marker for the starting "page" of entries. If not
+                passed, the API will return the first page of entries.
         Returns:
-            Iterator[~logging_v2.entries.LogEntry]
+            Generator[~logging_v2.LogEntry]
         """
 
         if resource_names is None:
@@ -305,6 +316,8 @@ class Logger(object):
             filter_=filter_,
             order_by=order_by,
             max_results=max_results,
+            page_size=page_size,
+            page_token=page_token,
         )
 
 

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -264,8 +264,6 @@ class Logger(object):
         resource_names=None,
         filter_=None,
         order_by=None,
-        page_size=None,
-        page_token=None,
         max_results=None
     ):
         """Return a page of log entries.
@@ -292,8 +290,7 @@ class Logger(object):
                 or :data:`~logging_v2.DESCENDING`.
             max_results (Optional[int]):
                 Optional. The maximum number of entries to return.
-                Non-positive values are ignored. Defaults
-                to unlimited.
+                Non-positive values are ignored. If None, uses API defaults.
 
         Returns:
             Iterator[~logging_v2.entries.LogEntry]

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -259,12 +259,7 @@ class Logger(object):
         client.logging_api.logger_delete(logger_name)
 
     def list_entries(
-        self,
-        *,
-        resource_names=None,
-        filter_=None,
-        order_by=None,
-        max_results=None
+        self, *, resource_names=None, filter_=None, order_by=None, max_results=None
     ):
         """Return a page of log entries.
 

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -266,6 +266,7 @@ class Logger(object):
         order_by=None,
         page_size=None,
         page_token=None,
+        max_results=None
     ):
         """Return a page of log entries.
 
@@ -289,16 +290,10 @@ class Logger(object):
                 By default, a 24 hour filter is applied.
             order_by (Optional[str]): One of :data:`~logging_v2.ASCENDING`
                 or :data:`~logging_v2.DESCENDING`.
-            page_size (Optional[int]):
-                Optional. The maximum number of entries in each page of results
-                from this request. Non-positive values are ignored. Defaults
-                to a sensible value set by the API.
-            page_token (Optional[str]):
-                Optional. If present, return the next batch of entries, using
-                the value, which must correspond to the ``nextPageToken`` value
-                returned in the previous response.  Deprecated: use the ``pages``
-                property of the returned iterator instead of manually passing
-                the token.
+            max_results (Optional[int]):
+                Optional. The maximum number of entries to return.
+                Non-positive values are ignored. Defaults
+                to unlimited.
 
         Returns:
             Iterator[~logging_v2.entries.LogEntry]
@@ -317,8 +312,7 @@ class Logger(object):
             resource_names=resource_names,
             filter_=filter_,
             order_by=order_by,
-            page_size=page_size,
-            page_token=page_token,
+            max_results=max_results,
         )
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -103,7 +103,7 @@ class Config(object):
 
 def setUpModule():
     Config.CLIENT = client.Client()
-    Config.HTTP_CLIENT =  client.Client(_use_grpc=False)
+    Config.HTTP_CLIENT = client.Client(_use_grpc=False)
 
 
 # Skip the test cases using bigquery, storage and pubsub clients for mTLS testing.
@@ -325,7 +325,10 @@ class TestLogging(unittest.TestCase):
             self.to_delete.append(logger)
 
             logger.log_text(
-                TEXT_PAYLOAD, insert_id=INSERT_ID, severity=SEVERITY, http_request=REQUEST
+                TEXT_PAYLOAD,
+                insert_id=INSERT_ID,
+                severity=SEVERITY,
+                http_request=REQUEST,
             )
             entries = _list_entries(logger)
 
@@ -743,6 +746,7 @@ class TestLogging(unittest.TestCase):
 
         self.assertEqual(sink.filter_, UPDATED_FILTER)
         self.assertEqual(sink.destination, dataset_uri)
+
     def test_api_equality_list_logs(self):
         unique_id = uuid.uuid1()
         gapic_logger = Config.CLIENT.logger(f"api-list-{unique_id}")
@@ -751,6 +755,7 @@ class TestLogging(unittest.TestCase):
         log_count = 5
         for i in range(log_count):
             gapic_logger.log_text(f"test {i}")
+
         def retryable():
             max_results = 3
             gapic_generator = gapic_logger.list_entries(max_results=max_results)
@@ -766,8 +771,12 @@ class TestLogging(unittest.TestCase):
             # should return in ascending order
             self.assertEqual(gapic_list[0].payload, "test 0")
             # test reverse ordering
-            gapic_generator = gapic_logger.list_entries(max_results=max_results, order_by=google.cloud.logging_v2.DESCENDING)
-            http_generator = http_logger.list_entries(max_results=max_results, order_by=google.cloud.logging_v2.DESCENDING)
+            gapic_generator = gapic_logger.list_entries(
+                max_results=max_results, order_by=google.cloud.logging_v2.DESCENDING
+            )
+            http_generator = http_logger.list_entries(
+                max_results=max_results, order_by=google.cloud.logging_v2.DESCENDING
+            )
             gapic_list, http_list = list(gapic_generator), list(http_generator)
             self.assertEqual(len(gapic_list), max_results)
             self.assertEqual(len(http_list), max_results)
@@ -777,8 +786,10 @@ class TestLogging(unittest.TestCase):
             self.assertEqual(gapic_list[0].payload, f"test {log_count-1}")
 
         RetryErrors(
-                (ServiceUnavailable, InternalServerError, AssertionError),
-                delay=2, backoff=2, max_tries=3
+            (ServiceUnavailable, InternalServerError, AssertionError),
+            delay=2,
+            backoff=2,
+            max_tries=3,
         )(retryable)()
 
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -36,6 +36,10 @@ from google.cloud.logging_v2.handlers import CloudLoggingHandler
 from google.cloud.logging_v2.handlers.transports import SyncTransport
 from google.cloud.logging_v2 import client
 from google.cloud.logging_v2.resource import Resource
+from google.cloud.logging_v2.entries import LogEntry
+from google.cloud.logging_v2.entries import ProtobufEntry
+from google.cloud.logging_v2.entries import StructEntry
+from google.cloud.logging_v2.entries import TextEntry
 
 from google.protobuf.struct_pb2 import Struct, Value, ListValue, NullValue
 
@@ -269,11 +273,11 @@ class TestLogging(unittest.TestCase):
         http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_http"))
         for logger in [gapic_logger, http_logger]:
             self.to_delete.append(logger)
-            # test gapic
             logger.log_text(TEXT_PAYLOAD)
             entries = _list_entries(logger)
             self.assertEqual(len(entries), 1)
             self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
+            self.assertTrue(isinstance(entries[0], TextEntry))
 
     def test_log_text_with_timestamp(self):
         text_payload = "System test: test_log_text_with_timestamp"

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -36,9 +36,6 @@ from google.cloud.logging_v2.handlers import CloudLoggingHandler
 from google.cloud.logging_v2.handlers.transports import SyncTransport
 from google.cloud.logging_v2 import client
 from google.cloud.logging_v2.resource import Resource
-from google.cloud.logging_v2.entries import LogEntry
-from google.cloud.logging_v2.entries import ProtobufEntry
-from google.cloud.logging_v2.entries import StructEntry
 from google.cloud.logging_v2.entries import TextEntry
 
 from google.protobuf.struct_pb2 import Struct, Value, ListValue, NullValue

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -251,39 +251,65 @@ class TestLogging(unittest.TestCase):
         for logger in [gapic_logger, http_logger]:
             logger.log_proto(req_struct)
 
+            # retrieve log
+            retry = RetryErrors((TooManyRequests, StopIteration), max_tries=8)
+            protobuf_entry = retry(lambda: next(logger.list_entries()))()
+
+            self.assertIsInstance(protobuf_entry, entries.ProtobufEntry)
+            self.assertIsNone(protobuf_entry.payload_pb)
+            self.assertIsInstance(protobuf_entry.payload_json, dict)
+            self.assertEqual(protobuf_entry.payload_json["@type"], type_url)
+            self.assertEqual(
+                protobuf_entry.to_api_repr()["protoPayload"]["@type"], type_url
+            )
+
+    def test_log_text(self):
+        TEXT_PAYLOAD = "System test: test_log_text"
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_text"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_http"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
+            # test gapic
+            logger.log_text(TEXT_PAYLOAD)
+            entries = _list_entries(logger)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
+
     def test_log_text_with_timestamp(self):
         text_payload = "System test: test_log_text_with_timestamp"
-        logger = Config.CLIENT.logger(self._logger_name("log_text_ts"))
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_text_ts"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_ts_http"))
         now = datetime.utcnow()
-
-        self.to_delete.append(logger)
-
-        logger.log_text(text_payload, timestamp=now)
-        entries = _list_entries(logger)
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, text_payload)
-        self.assertEqual(entries[0].timestamp, now.replace(tzinfo=UTC))
-        self.assertIsInstance(entries[0].received_timestamp, datetime)
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
+            logger.log_text(text_payload, timestamp=now)
+            entries = _list_entries(logger)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, text_payload)
+            self.assertEqual(entries[0].timestamp, now.replace(tzinfo=UTC))
+            self.assertIsInstance(entries[0].received_timestamp, datetime)
 
     def test_log_text_with_resource(self):
         text_payload = "System test: test_log_text_with_timestamp"
 
-        logger = Config.CLIENT.logger(self._logger_name("log_text_res"))
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_text_res"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_res_http"))
         now = datetime.utcnow()
-        resource = Resource(
-            type="gae_app",
-            labels={"module_id": "default", "version_id": "test", "zone": ""},
-        )
+        for logger in [gapic_logger, http_logger]:
+            resource = Resource(
+                type="gae_app",
+                labels={"module_id": "default", "version_id": "test", "zone": ""},
+            )
 
-        self.to_delete.append(logger)
+            self.to_delete.append(logger)
 
-        logger.log_text(text_payload, timestamp=now, resource=resource)
-        entries = _list_entries(logger)
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, text_payload)
-        # project_id is output only so we don't want it in assertion
-        del entries[0].resource.labels["project_id"]
-        self.assertEqual(entries[0].resource, resource)
+            logger.log_text(text_payload, timestamp=now, resource=resource)
+            entries = _list_entries(logger)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, text_payload)
+            # project_id is output only so we don't want it in assertion
+            del entries[0].resource.labels["project_id"]
+            self.assertEqual(entries[0].resource, resource)
 
     def test_log_text_w_metadata(self):
         TEXT_PAYLOAD = "System test: test_log_text"
@@ -293,35 +319,39 @@ class TestLogging(unittest.TestCase):
         URI = "https://api.example.com/endpoint"
         STATUS = 500
         REQUEST = {"requestMethod": METHOD, "requestUrl": URI, "status": STATUS}
-        logger = Config.CLIENT.logger(self._logger_name("log_text_md"))
-        self.to_delete.append(logger)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_text_md"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_md_http"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
 
-        logger.log_text(
-            TEXT_PAYLOAD, insert_id=INSERT_ID, severity=SEVERITY, http_request=REQUEST
-        )
-        entries = _list_entries(logger)
+            logger.log_text(
+                TEXT_PAYLOAD, insert_id=INSERT_ID, severity=SEVERITY, http_request=REQUEST
+            )
+            entries = _list_entries(logger)
 
-        self.assertEqual(len(entries), 1)
+            self.assertEqual(len(entries), 1)
 
-        entry = entries[0]
-        self.assertEqual(entry.payload, TEXT_PAYLOAD)
-        self.assertEqual(entry.insert_id, INSERT_ID)
-        self.assertEqual(entry.severity, SEVERITY)
+            entry = entries[0]
+            self.assertEqual(entry.payload, TEXT_PAYLOAD)
+            self.assertEqual(entry.insert_id, INSERT_ID)
+            self.assertEqual(entry.severity, SEVERITY)
 
-        request = entry.http_request
-        self.assertEqual(request["requestMethod"], METHOD)
-        self.assertEqual(request["requestUrl"], URI)
-        self.assertEqual(request["status"], STATUS)
+            request = entry.http_request
+            self.assertEqual(request["requestMethod"], METHOD)
+            self.assertEqual(request["requestUrl"], URI)
+            self.assertEqual(request["status"], STATUS)
 
     def test_log_struct(self):
-        logger = Config.CLIENT.logger(self._logger_name("log_struct"))
-        self.to_delete.append(logger)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_struct"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_struct_http"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
 
-        logger.log_struct(self.JSON_PAYLOAD)
-        entries = _list_entries(logger)
+            logger.log_struct(self.JSON_PAYLOAD)
+            entries = _list_entries(logger)
 
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
 
     def test_log_struct_w_metadata(self):
         INSERT_ID = "INSERTID"
@@ -330,54 +360,63 @@ class TestLogging(unittest.TestCase):
         URI = "https://api.example.com/endpoint"
         STATUS = 500
         REQUEST = {"requestMethod": METHOD, "requestUrl": URI, "status": STATUS}
-        logger = Config.CLIENT.logger(self._logger_name("log_struct_md"))
-        self.to_delete.append(logger)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_struct_md"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_struct_md_http"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
 
-        logger.log_struct(
-            self.JSON_PAYLOAD,
-            insert_id=INSERT_ID,
-            severity=SEVERITY,
-            http_request=REQUEST,
-        )
-        entries = _list_entries(logger)
+            logger.log_struct(
+                self.JSON_PAYLOAD,
+                insert_id=INSERT_ID,
+                severity=SEVERITY,
+                http_request=REQUEST,
+            )
+            entries = _list_entries(logger)
 
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
-        self.assertEqual(entries[0].insert_id, INSERT_ID)
-        self.assertEqual(entries[0].severity, SEVERITY)
-        request = entries[0].http_request
-        self.assertEqual(request["requestMethod"], METHOD)
-        self.assertEqual(request["requestUrl"], URI)
-        self.assertEqual(request["status"], STATUS)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
+            self.assertEqual(entries[0].insert_id, INSERT_ID)
+            self.assertEqual(entries[0].severity, SEVERITY)
+            request = entries[0].http_request
+            self.assertEqual(request["requestMethod"], METHOD)
+            self.assertEqual(request["requestUrl"], URI)
+            self.assertEqual(request["status"], STATUS)
 
     def test_log_w_text(self):
         TEXT_PAYLOAD = "System test: test_log_w_text"
-        logger = Config.CLIENT.logger(self._logger_name("log_w_text"))
-        self.to_delete.append(logger)
-        logger.log(TEXT_PAYLOAD)
-        entries = _list_entries(logger)
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_w_text"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_w_text"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
+            logger.log(TEXT_PAYLOAD)
+            entries = _list_entries(logger)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, TEXT_PAYLOAD)
 
     def test_log_w_struct(self):
-        logger = Config.CLIENT.logger(self._logger_name("log_w_struct"))
-        self.to_delete.append(logger)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_w_struct"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_w_struct_http"))
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
 
-        logger.log(self.JSON_PAYLOAD)
-        entries = _list_entries(logger)
+            logger.log(self.JSON_PAYLOAD)
+            entries = _list_entries(logger)
 
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].payload, self.JSON_PAYLOAD)
 
     def test_log_empty(self):
-        logger = Config.CLIENT.logger(self._logger_name("log_empty"))
-        self.to_delete.append(logger)
+        gapic_logger = Config.CLIENT.logger(self._logger_name("log_empty"))
+        http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_empty_http"))
 
-        logger.log()
-        entries = _list_entries(logger)
+        for logger in [gapic_logger, http_logger]:
+            self.to_delete.append(logger)
 
-        self.assertEqual(len(entries), 1)
-        self.assertIsNone(entries[0].payload)
+            logger.log()
+            entries = _list_entries(logger)
+
+            self.assertEqual(len(entries), 1)
+            self.assertIsNone(entries[0].payload)
 
     def test_log_handler_async(self):
         LOG_MESSAGE = "It was the worst of times"

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -32,7 +32,7 @@ PROJECT_PATH = f"projects/{PROJECT}"
 FILTER = "logName:syslog AND severity>=ERROR"
 
 
-class Test_LoggingAPI(object):
+class Test_LoggingAPI(unittest.TestCase):
     LOG_NAME = "log_name"
     LOG_PATH = f"projects/{PROJECT}/logs/{LOG_NAME}"
 
@@ -107,6 +107,47 @@ class Test_LoggingAPI(object):
         assert request.page_size == 42
         assert request.page_token == "token"
 
+    def test_list_logs_with_max_results(self):
+        client = self.make_logging_api()
+        log_entry_msg = LogEntryPB(log_name=self.LOG_PATH, text_payload="text")
+
+        with mock.patch.object(
+            type(client._gapic_api.transport.list_log_entries), "__call__"
+        ) as call:
+            call.return_value = logging_v2.types.ListLogEntriesResponse(entries=[log_entry_msg, log_entry_msg])
+            result = client.list_entries(
+                [PROJECT_PATH],
+                filter_=FILTER,
+                order_by=google.cloud.logging.ASCENDING,
+                page_size=42,
+                page_token="token",
+                max_results=1
+            )
+
+        # Check the request
+        call.assert_called_once()
+        assert len(list(result)) == 1
+
+    def test_list_logs_negative_max_results(self):
+        client = self.make_logging_api()
+
+        with self.assertRaises(ValueError):
+            with mock.patch.object(
+                type(client._gapic_api.transport.list_log_entries), "__call__"
+            ) as call:
+                call.return_value = logging_v2.types.ListLogEntriesResponse(entries=[])
+                result = client.list_entries(
+                    [PROJECT_PATH],
+                    filter_=FILTER,
+                    order_by=google.cloud.logging.ASCENDING,
+                    page_size=42,
+                    page_token="token",
+                    max_results=-1
+                )
+            # Check the request
+            list(result)
+            call.assert_called_once()
+
     def test_write_entries_single(self):
         client = self.make_logging_api()
 
@@ -141,7 +182,7 @@ class Test_LoggingAPI(object):
         assert call.call_args.args[0].log_name == self.LOG_PATH
 
 
-class Test_SinksAPI(object):
+class Test_SinksAPI(unittest.TestCase):
     SINK_NAME = "sink_name"
     PARENT_PATH = f"projects/{PROJECT}"
     SINK_PATH = f"projects/{PROJECT}/sinks/{SINK_NAME}"
@@ -207,6 +248,38 @@ class Test_SinksAPI(object):
         assert request.parent == self.PARENT_PATH
         assert request.page_size == 42
         assert request.page_token == "token"
+
+    def test_list_sinks_with_max_results(self):
+        client = self.make_sinks_api()
+        sink_msg = LogSink(
+            name=self.SINK_NAME, destination=self.DESTINATION_URI, filter=FILTER
+        )
+
+        with mock.patch.object(
+            type(client._gapic_api.transport.list_sinks), "__call__"
+        ) as call:
+            call.return_value = logging_v2.types.ListSinksResponse(sinks=[sink_msg, sink_msg])
+            result = client.list_sinks(
+                self.PARENT_PATH, page_size=42, page_token="token", max_results=1
+            )
+        # Check the request
+        call.assert_called_once()
+        assert len(list(result)) == 1
+
+    def test_list_sinks_negative_max_results(self):
+        client = self.make_sinks_api()
+
+        with self.assertRaises(ValueError):
+            with mock.patch.object(
+                type(client._gapic_api.transport.list_sinks), "__call__"
+            ) as call:
+                call.return_value = logging_v2.types.ListSinksResponse(sinks=[])
+                result = client.list_sinks(
+                    self.PARENT_PATH, page_size=42, page_token="token", max_results=-1
+                )
+            # Check the request
+            list(result)
+            call.assert_called_once()
 
     def test_sink_create(self):
         client = self.make_sinks_api()
@@ -315,7 +388,7 @@ class Test_SinksAPI(object):
         assert request.sink_name == self.SINK_PATH
 
 
-class Test_MetricsAPI(object):
+class Test_MetricsAPI(unittest.TestCase):
     METRIC_NAME = "metric_name"
     METRIC_PATH = f"projects/{PROJECT}/metrics/{METRIC_NAME}"
     DESCRIPTION = "Description"
@@ -378,6 +451,37 @@ class Test_MetricsAPI(object):
         assert request.parent == PROJECT_PATH
         assert request.page_size == 42
         assert request.page_token == "token"
+
+    def test_list_metrics_with_max_results(self):
+        client = self.make_metrics_api()
+        metric = logging_v2.types.LogMetric(
+            name=self.METRIC_PATH, description=self.DESCRIPTION, filter=FILTER
+        )
+        with mock.patch.object(
+            type(client._gapic_api.transport.list_log_metrics), "__call__"
+        ) as call:
+            call.return_value = logging_v2.types.ListLogMetricsResponse(metrics=[metric, metric])
+            result = client.list_metrics(
+                PROJECT, page_size=42, page_token="token", max_results=1
+            )
+        # Check the request
+        call.assert_called_once()
+        assert len(list(result)) == 1
+
+    def test_list_metrics_negative_max_results(self):
+        client = self.make_metrics_api()
+
+        with self.assertRaises(ValueError):
+            with mock.patch.object(
+                type(client._gapic_api.transport.list_log_metrics), "__call__"
+            ) as call:
+                call.return_value = logging_v2.types.ListLogMetricsResponse(metrics=[])
+                result = client.list_metrics(
+                    PROJECT, page_size=42, page_token="token", max_results=-1
+                )
+            # Check the request
+            list(result)
+            call.assert_called_once()
 
     def test_metric_create(self):
         client = self.make_metrics_api()

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -114,14 +114,16 @@ class Test_LoggingAPI(unittest.TestCase):
         with mock.patch.object(
             type(client._gapic_api.transport.list_log_entries), "__call__"
         ) as call:
-            call.return_value = logging_v2.types.ListLogEntriesResponse(entries=[log_entry_msg, log_entry_msg])
+            call.return_value = logging_v2.types.ListLogEntriesResponse(
+                entries=[log_entry_msg, log_entry_msg]
+            )
             result = client.list_entries(
                 [PROJECT_PATH],
                 filter_=FILTER,
                 order_by=google.cloud.logging.ASCENDING,
                 page_size=42,
                 page_token="token",
-                max_results=1
+                max_results=1,
             )
 
         # Check the request
@@ -142,7 +144,7 @@ class Test_LoggingAPI(unittest.TestCase):
                     order_by=google.cloud.logging.ASCENDING,
                     page_size=42,
                     page_token="token",
-                    max_results=-1
+                    max_results=-1,
                 )
             # Check the request
             list(result)
@@ -258,7 +260,9 @@ class Test_SinksAPI(unittest.TestCase):
         with mock.patch.object(
             type(client._gapic_api.transport.list_sinks), "__call__"
         ) as call:
-            call.return_value = logging_v2.types.ListSinksResponse(sinks=[sink_msg, sink_msg])
+            call.return_value = logging_v2.types.ListSinksResponse(
+                sinks=[sink_msg, sink_msg]
+            )
             result = client.list_sinks(
                 self.PARENT_PATH, page_size=42, page_token="token", max_results=1
             )
@@ -460,7 +464,9 @@ class Test_MetricsAPI(unittest.TestCase):
         with mock.patch.object(
             type(client._gapic_api.transport.list_log_metrics), "__call__"
         ) as call:
-            call.return_value = logging_v2.types.ListLogMetricsResponse(metrics=[metric, metric])
+            call.return_value = logging_v2.types.ListLogMetricsResponse(
+                metrics=[metric, metric]
+            )
             result = client.list_metrics(
                 PROJECT, page_size=42, page_token="token", max_results=1
             )

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -392,11 +392,7 @@ class Test_SinksAPI(unittest.TestCase):
                     "filter": self.FILTER,
                     "destination": self.DESTINATION_URI,
                 },
-                {
-                    "name": "test",
-                    "filter": "test",
-                    "destination": "test",
-                }
+                {"name": "test", "filter": "test", "destination": "test",},
             ],
         }
         # try with negative max_results

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -172,10 +172,10 @@ class Test_LoggingAPI(unittest.TestCase):
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
         # try with negative max_results
-        client._connection = _Connection(RETURNED)
-        api = self._make_one(client)
-        empty = list(api.list_entries([self.PROJECT_PATH], max_results=-1))
-        self.assertEqual(empty, [])
+        with self.assertRaises(ValueError):
+            client._connection = _Connection(RETURNED)
+            api = self._make_one(client)
+            empty = list(api.list_entries([self.PROJECT_PATH], max_results=-1))
         # try with max_results of 0
         client._connection = _Connection(RETURNED)
         api = self._make_one(client)
@@ -394,11 +394,11 @@ class Test_SinksAPI(unittest.TestCase):
             ],
         }
         # try with negative max_results
-        conn = _Connection(RETURNED)
-        client = _Client(conn)
-        api = self._make_one(client)
-        empty = list(api.list_sinks(self.PROJECT_PATH, max_results=-1))
-        self.assertEqual(empty, [])
+        with self.assertRaises(ValueError):
+            conn = _Connection(RETURNED)
+            client = _Client(conn)
+            api = self._make_one(client)
+            empty = list(api.list_sinks(self.PROJECT_PATH, max_results=-1))
         # try with max_results of 0
         conn = _Connection(RETURNED)
         client = _Client(conn)
@@ -663,11 +663,11 @@ class Test_MetricsAPI(unittest.TestCase):
             ],
         }
         # try with negative max_results
-        conn = _Connection(RETURNED)
-        client = _Client(conn)
-        api = self._make_one(client)
-        empty = list(api.list_metrics(self.PROJECT, max_results=-1))
-        self.assertEqual(empty, [])
+        with self.assertRaises(ValueError):
+            conn = _Connection(RETURNED)
+            client = _Client(conn)
+            api = self._make_one(client)
+            empty = list(api.list_metrics(self.PROJECT, max_results=-1))
         # try with max_results of 0
         conn = _Connection(RETURNED)
         client = _Client(conn)

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -129,16 +129,21 @@ class Test_LoggingAPI(unittest.TestCase):
         NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
         return NOW, _datetime_to_rfc3339_w_nanos(NOW)
 
-    def test_list_entries_no_paging(self):
+    def test_list_entries_with_limits(self):
         from google.cloud.logging import Client
         from google.cloud.logging import TextEntry
         from google.cloud.logging import Logger
 
         NOW, TIMESTAMP = self._make_timestamp()
         IID = "IID"
+        IID1 = "IID1"
+        IID2 = "IID2"
         TEXT = "TEXT"
         SENT = {"resourceNames": [self.PROJECT_PATH]}
         TOKEN = "TOKEN"
+        PAYLOAD = {"message": "MESSAGE", "weather": "partly cloudy"}
+        PROTO_PAYLOAD = PAYLOAD.copy()
+        PROTO_PAYLOAD["@type"] = "type.googleapis.com/testing.example"
         RETURNED = {
             "entries": [
                 {
@@ -147,24 +152,42 @@ class Test_LoggingAPI(unittest.TestCase):
                     "resource": {"type": "global"},
                     "timestamp": TIMESTAMP,
                     "logName": f"projects/{self.PROJECT}/logs/{self.LOGGER_NAME}",
-                }
+                },
+                {
+                    "jsonPayload": PAYLOAD,
+                    "insertId": IID1,
+                    "resource": {"type": "global"},
+                    "timestamp": TIMESTAMP,
+                    "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+                },
+                {
+                    "protoPayload": PROTO_PAYLOAD,
+                    "insertId": IID2,
+                    "resource": {"type": "global"},
+                    "timestamp": TIMESTAMP,
+                    "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+                },
             ],
-            "nextPageToken": TOKEN,
         }
         client = Client(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
+        # try with negative max_results
         client._connection = _Connection(RETURNED)
         api = self._make_one(client)
-
-        iterator = api.list_entries([self.PROJECT_PATH])
-        page = next(iterator.pages)
-        entries = list(page)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertEqual(token, TOKEN)
-        # Then check the entries returned.
+        empty = list(api.list_entries([self.PROJECT_PATH], max_results=-1))
+        self.assertEqual(empty, [])
+        # try with max_results of 0
+        client._connection = _Connection(RETURNED)
+        api = self._make_one(client)
+        empty = list(api.list_entries([self.PROJECT_PATH], max_results=0))
+        self.assertEqual(empty, [])
+        # try with single result
+        client._connection = _Connection(RETURNED)
+        api = self._make_one(client)
+        iterator = api.list_entries([self.PROJECT_PATH], max_results=1)
+        entries = list(iterator)
+        # check the entries returned.
         self.assertEqual(len(entries), 1)
         entry = entries[0]
         self.assertIsInstance(entry, TextEntry)
@@ -183,7 +206,7 @@ class Test_LoggingAPI(unittest.TestCase):
             called_with, {"method": "POST", "path": expected_path, "data": SENT}
         )
 
-    def test_list_entries_w_paging(self):
+    def test_list_entries(self):
         from google.cloud.logging import DESCENDING
         from google.cloud.logging import Client
         from google.cloud.logging import Logger
@@ -241,11 +264,8 @@ class Test_LoggingAPI(unittest.TestCase):
             page_token=TOKEN,
         )
         entries = list(iterator)
-        token = iterator.next_page_token
 
-        # First check the token.
-        self.assertIsNone(token)
-        # Then check the entries returned.
+        # Check the entries returned.
         self.assertEqual(len(entries), 2)
         entry1 = entries[0]
         self.assertIsInstance(entry1, StructEntry)
@@ -361,7 +381,7 @@ class Test_SinksAPI(unittest.TestCase):
         self.assertIs(api._client, client)
         self.assertEqual(api.api_request, connection.api_request)
 
-    def test_list_sinks_no_paging(self):
+    def test_list_sinks_max_returned(self):
         from google.cloud.logging import Sink
 
         TOKEN = "TOKEN"
@@ -371,22 +391,33 @@ class Test_SinksAPI(unittest.TestCase):
                     "name": self.SINK_PATH,
                     "filter": self.FILTER,
                     "destination": self.DESTINATION_URI,
+                },
+                {
+                    "name": "test",
+                    "filter": "test",
+                    "destination": "test",
                 }
             ],
-            "nextPageToken": TOKEN,
         }
+        # try with negative max_results
         conn = _Connection(RETURNED)
         client = _Client(conn)
         api = self._make_one(client)
-
-        iterator = api.list_sinks(self.PROJECT_PATH)
-        page = next(iterator.pages)
-        sinks = list(page)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertEqual(token, TOKEN)
-        # Then check the sinks returned.
+        empty = list(api.list_sinks(self.PROJECT_PATH, max_results=-1))
+        self.assertEqual(empty, [])
+        # try with max_results of 0
+        conn = _Connection(RETURNED)
+        client = _Client(conn)
+        api = self._make_one(client)
+        empty = list(api.list_sinks(self.PROJECT_PATH, max_results=0))
+        self.assertEqual(empty, [])
+        # try with single result
+        conn = _Connection(RETURNED)
+        client = _Client(conn)
+        api = self._make_one(client)
+        iterator = api.list_sinks(self.PROJECT_PATH, max_results=1)
+        sinks = list(iterator)
+        # Check the sinks returned.
         self.assertEqual(len(sinks), 1)
         sink = sinks[0]
         self.assertIsInstance(sink, Sink)
@@ -401,7 +432,7 @@ class Test_SinksAPI(unittest.TestCase):
             called_with, {"method": "GET", "path": path, "query_params": {}}
         )
 
-    def test_list_sinks_w_paging(self):
+    def test_list_sinks(self):
         from google.cloud.logging import Sink
 
         TOKEN = "TOKEN"
@@ -423,11 +454,7 @@ class Test_SinksAPI(unittest.TestCase):
             self.PROJECT_PATH, page_size=PAGE_SIZE, page_token=TOKEN
         )
         sinks = list(iterator)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertIsNone(token)
-        # Then check the sinks returned.
+        # Check the sinks returned.
         self.assertEqual(len(sinks), 1)
         sink = sinks[0]
         self.assertIsInstance(sink, Sink)
@@ -632,26 +659,36 @@ class Test_MetricsAPI(unittest.TestCase):
     def _make_one(self, *args, **kw):
         return self._get_target_class()(*args, **kw)
 
-    def test_list_metrics_no_paging(self):
+    def test_list_metrics_max_results(self):
         from google.cloud.logging import Metric
 
         TOKEN = "TOKEN"
         RETURNED = {
-            "metrics": [{"name": self.METRIC_PATH, "filter": self.FILTER}],
-            "nextPageToken": TOKEN,
+            "metrics": [
+                {"name": self.METRIC_PATH, "filter": self.FILTER},
+                {"name": "test", "filter": "test"},
+            ],
         }
+        # try with negative max_results
+        conn = _Connection(RETURNED)
+        client = _Client(conn)
+        api = self._make_one(client)
+        empty = list(api.list_metrics(self.PROJECT, max_results=-1))
+        self.assertEqual(empty, [])
+        # try with max_results of 0
+        conn = _Connection(RETURNED)
+        client = _Client(conn)
+        api = self._make_one(client)
+        empty = list(api.list_metrics(self.PROJECT, max_results=0))
+        self.assertEqual(empty, [])
+        # try with single result
         conn = _Connection(RETURNED)
         client = _Client(conn)
         api = self._make_one(client)
 
-        iterator = api.list_metrics(self.PROJECT)
-        page = next(iterator.pages)
-        metrics = list(page)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertEqual(token, TOKEN)
-        # Then check the metrics returned.
+        iterator = api.list_metrics(self.PROJECT, max_results=1)
+        metrics = list(iterator)
+        # Check the metrics returned.
         self.assertEqual(len(metrics), 1)
         metric = metrics[0]
         self.assertIsInstance(metric, Metric)
@@ -666,7 +703,7 @@ class Test_MetricsAPI(unittest.TestCase):
             called_with, {"method": "GET", "path": path, "query_params": {}}
         )
 
-    def test_list_metrics_w_paging(self):
+    def test_list_metrics(self):
         from google.cloud.logging import Metric
 
         TOKEN = "TOKEN"
@@ -678,11 +715,7 @@ class Test_MetricsAPI(unittest.TestCase):
 
         iterator = api.list_metrics(self.PROJECT, page_size=PAGE_SIZE, page_token=TOKEN)
         metrics = list(iterator)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertIsNone(token)
-        # Then check the metrics returned.
+        # Check the metrics returned.
         self.assertEqual(len(metrics), 1)
         metric = metrics[0]
         self.assertIsInstance(metric, Metric)

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -140,7 +140,6 @@ class Test_LoggingAPI(unittest.TestCase):
         IID2 = "IID2"
         TEXT = "TEXT"
         SENT = {"resourceNames": [self.PROJECT_PATH]}
-        TOKEN = "TOKEN"
         PAYLOAD = {"message": "MESSAGE", "weather": "partly cloudy"}
         PROTO_PAYLOAD = PAYLOAD.copy()
         PROTO_PAYLOAD["@type"] = "type.googleapis.com/testing.example"
@@ -384,7 +383,6 @@ class Test_SinksAPI(unittest.TestCase):
     def test_list_sinks_max_returned(self):
         from google.cloud.logging import Sink
 
-        TOKEN = "TOKEN"
         RETURNED = {
             "sinks": [
                 {
@@ -392,7 +390,7 @@ class Test_SinksAPI(unittest.TestCase):
                     "filter": self.FILTER,
                     "destination": self.DESTINATION_URI,
                 },
-                {"name": "test", "filter": "test", "destination": "test",},
+                {"name": "test", "filter": "test", "destination": "test"},
             ],
         }
         # try with negative max_results
@@ -658,7 +656,6 @@ class Test_MetricsAPI(unittest.TestCase):
     def test_list_metrics_max_results(self):
         from google.cloud.logging import Metric
 
-        TOKEN = "TOKEN"
         RETURNED = {
             "metrics": [
                 {"name": self.METRIC_PATH, "filter": self.FILTER},

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -259,7 +259,6 @@ class TestClient(unittest.TestCase):
 
         IID = "IID"
         TEXT = "TEXT"
-        TOKEN = "TOKEN"
         ENTRIES = [
             {
                 "textPayload": TEXT,
@@ -272,13 +271,11 @@ class TestClient(unittest.TestCase):
         client = self._make_one(
             project=self.PROJECT, credentials=creds, _use_grpc=False
         )
-        returned = {"entries": ENTRIES, "nextPageToken": TOKEN}
+        returned = {"entries": ENTRIES}
         client._connection = _Connection(returned)
 
         iterator = client.list_entries()
-        page = next(iterator.pages)
-        entries = list(page)
-        token = iterator.next_page_token
+        entries = list(iterator)
 
         self.assertEqual(len(entries), 1)
         entry = entries[0]
@@ -289,7 +286,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(logger.name, self.LOGGER_NAME)
         self.assertIs(logger.client, client)
         self.assertEqual(logger.project, self.PROJECT)
-        self.assertEqual(token, TOKEN)
 
         # check call payload
         call_payload_no_filter = deepcopy(client._connection._called_with)
@@ -302,6 +298,7 @@ class TestClient(unittest.TestCase):
                 "data": {
                     "filter": "removed",
                     "resourceNames": [f"projects/{self.PROJECT}"],
+
                 },
             },
         )
@@ -342,6 +339,12 @@ class TestClient(unittest.TestCase):
                 "resource": {"type": "global"},
                 "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
             },
+            {
+                "protoPayload": "ignored",
+                "insertId": "ignored",
+                "resource": {"type": "global"},
+                "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+            },
         ]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
@@ -355,13 +358,10 @@ class TestClient(unittest.TestCase):
             order_by=DESCENDING,
             page_size=PAGE_SIZE,
             page_token=TOKEN,
+            max_results=2,
         )
         entries = list(iterator)
-        token = iterator.next_page_token
-
-        # First, check the token.
-        self.assertIsNone(token)
-        # Then check the entries.
+        # Check the entries.
         self.assertEqual(len(entries), 2)
         entry = entries[0]
         self.assertIsInstance(entry, StructEntry)
@@ -423,7 +423,6 @@ class TestClient(unittest.TestCase):
         PAYLOAD = {"message": "MESSAGE", "weather": "partly cloudy"}
         PROTO_PAYLOAD = PAYLOAD.copy()
         PROTO_PAYLOAD["@type"] = "type.googleapis.com/testing.example"
-        TOKEN = "TOKEN"
         PAGE_SIZE = 42
         ENTRIES = [
             {
@@ -450,14 +449,9 @@ class TestClient(unittest.TestCase):
             filter_=INPUT_FILTER,
             order_by=DESCENDING,
             page_size=PAGE_SIZE,
-            page_token=TOKEN,
         )
         entries = list(iterator)
-        token = iterator.next_page_token
-
-        # First, check the token.
-        self.assertIsNone(token)
-        # Then check the entries.
+        # Check the entries.
         self.assertEqual(len(entries), 2)
         entry = entries[0]
         self.assertIsInstance(entry, StructEntry)
@@ -491,7 +485,6 @@ class TestClient(unittest.TestCase):
                     "filter": INPUT_FILTER,
                     "orderBy": DESCENDING,
                     "pageSize": PAGE_SIZE,
-                    "pageToken": TOKEN,
                     "resourceNames": [f"projects/{PROJECT1}", f"projects/{PROJECT2}"],
                 },
             },
@@ -529,7 +522,6 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging import Sink
 
         PROJECT = "PROJECT"
-        TOKEN = "TOKEN"
         SINK_NAME = "sink_name"
         FILTER = "logName:syslog AND severity>=ERROR"
         SINKS = [
@@ -538,17 +530,13 @@ class TestClient(unittest.TestCase):
         client = self._make_one(
             project=PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
-        returned = {"sinks": SINKS, "nextPageToken": TOKEN}
+        returned = {"sinks": SINKS}
         client._connection = _Connection(returned)
 
         iterator = client.list_sinks()
-        page = next(iterator.pages)
-        sinks = list(page)
-        token = iterator.next_page_token
+        sinks = list(iterator)
 
-        # First check the token.
-        self.assertEqual(token, TOKEN)
-        # Then check the sinks returned.
+        # Check the sinks returned.
         self.assertEqual(len(sinks), 1)
         sink = sinks[0]
         self.assertIsInstance(sink, Sink)
@@ -573,7 +561,8 @@ class TestClient(unittest.TestCase):
         TOKEN = "TOKEN"
         PAGE_SIZE = 42
         SINKS = [
-            {"name": SINK_NAME, "filter": FILTER, "destination": self.DESTINATION_URI}
+            {"name": SINK_NAME, "filter": FILTER, "destination": self.DESTINATION_URI},
+            {"name": "test", "filter": "test", "destination": "test"}
         ]
         client = self._make_one(
             project=PROJECT, credentials=_make_credentials(), _use_grpc=False
@@ -581,13 +570,9 @@ class TestClient(unittest.TestCase):
         returned = {"sinks": SINKS}
         client._connection = _Connection(returned)
 
-        iterator = client.list_sinks(page_size=PAGE_SIZE, page_token=TOKEN)
+        iterator = client.list_sinks(page_size=PAGE_SIZE, page_token=TOKEN, max_results=1)
         sinks = list(iterator)
-        token = iterator.next_page_token
-
-        # First check the token.
-        self.assertIsNone(token)
-        # Then check the sinks returned.
+        # Check the sinks returned.
         self.assertEqual(len(sinks), 1)
         sink = sinks[0]
         self.assertIsInstance(sink, Sink)
@@ -678,29 +663,30 @@ class TestClient(unittest.TestCase):
         from google.cloud.logging import Metric
 
         token = "TOKEN"
-        next_token = "T00KEN"
         page_size = 42
         metrics = [
             {
                 "name": self.METRIC_NAME,
                 "filter": self.FILTER,
                 "description": self.DESCRIPTION,
+            },
+            {
+                "name": "test",
+                "filter": "test",
+                "description": "test",
             }
+
         ]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
-        returned = {"metrics": metrics, "nextPageToken": next_token}
+        returned = {"metrics": metrics}
         client._connection = _Connection(returned)
 
         # Execute request.
-        iterator = client.list_metrics(page_size=page_size, page_token=token)
-        page = next(iterator.pages)
-        metrics = list(page)
-
-        # First check the token.
-        self.assertEqual(iterator.next_page_token, next_token)
-        # Then check the metrics returned.
+        iterator = client.list_metrics(page_size=page_size, page_token=token, max_results=1)
+        metrics = list(iterator)
+        # Check the metrics returned.
         self.assertEqual(len(metrics), 1)
         metric = metrics[0]
         self.assertIsInstance(metric, Metric)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -298,7 +298,6 @@ class TestClient(unittest.TestCase):
                 "data": {
                     "filter": "removed",
                     "resourceNames": [f"projects/{self.PROJECT}"],
-
                 },
             },
         )
@@ -562,7 +561,7 @@ class TestClient(unittest.TestCase):
         PAGE_SIZE = 42
         SINKS = [
             {"name": SINK_NAME, "filter": FILTER, "destination": self.DESTINATION_URI},
-            {"name": "test", "filter": "test", "destination": "test"}
+            {"name": "test", "filter": "test", "destination": "test"},
         ]
         client = self._make_one(
             project=PROJECT, credentials=_make_credentials(), _use_grpc=False
@@ -570,7 +569,9 @@ class TestClient(unittest.TestCase):
         returned = {"sinks": SINKS}
         client._connection = _Connection(returned)
 
-        iterator = client.list_sinks(page_size=PAGE_SIZE, page_token=TOKEN, max_results=1)
+        iterator = client.list_sinks(
+            page_size=PAGE_SIZE, page_token=TOKEN, max_results=1
+        )
         sinks = list(iterator)
         # Check the sinks returned.
         self.assertEqual(len(sinks), 1)
@@ -670,12 +671,7 @@ class TestClient(unittest.TestCase):
                 "filter": self.FILTER,
                 "description": self.DESCRIPTION,
             },
-            {
-                "name": "test",
-                "filter": "test",
-                "description": "test",
-            }
-
+            {"name": "test", "filter": "test", "description": "test",},
         ]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
@@ -684,7 +680,9 @@ class TestClient(unittest.TestCase):
         client._connection = _Connection(returned)
 
         # Execute request.
-        iterator = client.list_metrics(page_size=page_size, page_token=token, max_results=1)
+        iterator = client.list_metrics(
+            page_size=page_size, page_token=token, max_results=1
+        )
         metrics = list(iterator)
         # Check the metrics returned.
         self.assertEqual(len(metrics), 1)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -671,7 +671,7 @@ class TestClient(unittest.TestCase):
                 "filter": self.FILTER,
                 "description": self.DESCRIPTION,
             },
-            {"name": "test", "filter": "test", "description": "test",},
+            {"name": "test", "filter": "test", "description": "test"},
         ]
         client = self._make_one(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -838,6 +838,7 @@ class TestLogger(unittest.TestCase):
             },
         )
 
+
 class TestBatch(unittest.TestCase):
 
     PROJECT = "test-project"

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -610,18 +610,15 @@ class TestLogger(unittest.TestCase):
         client = Client(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
-        returned = {"nextPageToken": TOKEN}
+        returned = {}
         client._connection = _Connection(returned)
 
         logger = self._make_one(self.LOGGER_NAME, client=client)
 
         iterator = logger.list_entries()
-        page = next(iterator.pages)
-        entries = list(page)
-        token = iterator.next_page_token
+        entries = list(iterator)
 
         self.assertEqual(len(entries), 0)
-        self.assertEqual(token, TOKEN)
         LOG_FILTER = "logName=projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME)
 
         # check call payload
@@ -668,10 +665,8 @@ class TestLogger(unittest.TestCase):
             page_token=TOKEN,
         )
         entries = list(iterator)
-        token = iterator.next_page_token
 
         self.assertEqual(len(entries), 0)
-        self.assertIsNone(token)
         # self.assertEqual(client._listed, LISTED)
         # check call payload
         call_payload_no_filter = deepcopy(client._connection._called_with)
@@ -728,10 +723,8 @@ class TestLogger(unittest.TestCase):
             page_token=TOKEN,
         )
         entries = list(iterator)
-        token = iterator.next_page_token
 
         self.assertEqual(len(entries), 0)
-        self.assertIsNone(token)
         # self.assertEqual(client._listed, LISTED)
         # check call payload
         LOG_FILTER = "logName=projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME,)
@@ -751,6 +744,99 @@ class TestLogger(unittest.TestCase):
             },
         )
 
+    def test_list_entries_limit(self):
+        from google.cloud.logging import DESCENDING
+        from google.cloud.logging import ProtobufEntry
+        from google.cloud.logging import StructEntry
+        from google.cloud.logging import Logger
+        from google.cloud.logging import Client
+
+        PROJECT1 = "PROJECT1"
+        PROJECT2 = "PROJECT2"
+        INPUT_FILTER = "logName:LOGNAME"
+        IID1 = "IID1"
+        IID2 = "IID2"
+        PAYLOAD = {"message": "MESSAGE", "weather": "partly cloudy"}
+        PROTO_PAYLOAD = PAYLOAD.copy()
+        PROTO_PAYLOAD["@type"] = "type.googleapis.com/testing.example"
+        TOKEN = "TOKEN"
+        PAGE_SIZE = 42
+        ENTRIES = [
+            {
+                "jsonPayload": PAYLOAD,
+                "insertId": IID1,
+                "resource": {"type": "global"},
+                "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+            },
+            {
+                "protoPayload": PROTO_PAYLOAD,
+                "insertId": IID2,
+                "resource": {"type": "global"},
+                "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+            },
+            {
+                "protoPayload": "ignored",
+                "insertId": "ignored",
+                "resource": {"type": "global"},
+                "logName": "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME),
+            },
+        ]
+        client = Client(
+            project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
+        )
+        returned = {"entries": ENTRIES}
+        client._connection = _Connection(returned)
+        logger = self._make_one(self.LOGGER_NAME, client=client)
+
+        iterator = logger.list_entries(
+            resource_names=[f"projects/{PROJECT1}", f"projects/{PROJECT2}"],
+            filter_=INPUT_FILTER,
+            order_by=DESCENDING,
+            page_size=PAGE_SIZE,
+            page_token=TOKEN,
+            max_results=2,
+        )
+        entries = list(iterator)
+        # Check the entries.
+        self.assertEqual(len(entries), 2)
+        entry = entries[0]
+        self.assertIsInstance(entry, StructEntry)
+        self.assertEqual(entry.insert_id, IID1)
+        self.assertEqual(entry.payload, PAYLOAD)
+        logger = entry.logger
+        self.assertIsInstance(logger, Logger)
+        self.assertEqual(logger.name, self.LOGGER_NAME)
+        self.assertIs(logger.client, client)
+        self.assertEqual(logger.project, self.PROJECT)
+
+        entry = entries[1]
+        self.assertIsInstance(entry, ProtobufEntry)
+        self.assertEqual(entry.insert_id, IID2)
+        self.assertEqual(entry.payload, PROTO_PAYLOAD)
+        logger = entry.logger
+        self.assertEqual(logger.name, self.LOGGER_NAME)
+        self.assertIs(logger.client, client)
+        self.assertEqual(logger.project, self.PROJECT)
+
+        self.assertIs(entries[0].logger, entries[1].logger)
+
+        # check call payload
+        call_payload_no_filter = deepcopy(client._connection._called_with)
+        call_payload_no_filter["data"]["filter"] = "removed"
+        self.assertEqual(
+            call_payload_no_filter,
+            {
+                "path": "/entries:list",
+                "method": "POST",
+                "data": {
+                    "filter": "removed",
+                    "orderBy": DESCENDING,
+                    "pageSize": PAGE_SIZE,
+                    "pageToken": TOKEN,
+                    "resourceNames": [f"projects/{PROJECT1}", f"projects/{PROJECT2}"],
+                },
+            },
+        )
 
 class TestBatch(unittest.TestCase):
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -605,8 +605,6 @@ class TestLogger(unittest.TestCase):
     def test_list_entries_defaults(self):
         from google.cloud.logging import Client
 
-        TOKEN = "TOKEN"
-
         client = Client(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )


### PR DESCRIPTION
This PR is for the staged v3.0.0 branch

We have two separate transport options for this library: [gRPC](https://github.com/googleapis/python-logging/blob/28d141d0e8ed4560d2e33f8de0d43b0825a7f33f/google/cloud/logging_v2/_gapic.py) and [HTTP](https://github.com/googleapis/python-logging/blob/28d141d0e8ed4560d2e33f8de0d43b0825a7f33f/google/cloud/logging_v2/_http.py). They expose the same interface, but previously returned different types.

This PR wraps the HTTP `list_*` functions in a python generator, consistent with how the gRPC version works. Additionally, it adds a new `max_results` argument, so users can decide how many objects they want to return before stopping. This new argument will work consistently for both options.

Fixes https://github.com/googleapis/python-logging/issues/154, https://github.com/googleapis/python-logging/issues/136, https://github.com/googleapis/python-logging/issues/203