### PR TITLE
chore(tests): added missing dependency

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -72,6 +72,12 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
+
+##### TMP
+set -x
+${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
+#####
+
 python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -73,11 +73,6 @@ echo $ENVCTL_ID
 # Run the specified environment test
 set +e
 
-##### TMP
-set -x
-${PROJECT_ROOT}/tests/environment/envctl/envctl python $ENVIRONMENT deploy
-#####
-
 python3.6 -m nox --session "tests(language='python', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 


### PR DESCRIPTION
The appengine standard environment tests started failing because of a missing dependency requirement (`pytz`). This PR updates the submodule to the latest version, which has the dependency added
