### PR TITLE
fix: exception log message format

### DIFF
--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -15,7 +15,6 @@
 """Logging handler for printing formatted structured logs to standard output.
 """
 import json
-from copy import copy
 import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
@@ -60,9 +59,6 @@ class StructuredLogHandler(logging.StreamHandler):
         Returns:
             str: A JSON string formatted for GKE fluentd.
         """
-        # remove unwanted fields
-        record = copy(record)
-        record.exc_info = None
         # let other formatters alter the message
         super_payload = None
         if record.msg:
@@ -70,6 +66,9 @@ class StructuredLogHandler(logging.StreamHandler):
             super_payload = super(StructuredLogHandler, self).format(record)
         # properly break any formatting in string to make it json safe
         record._formatted_msg = json.dumps(super_payload or "")
+        # remove exception info to avoid duplicating it
+        record.exc_info = None
+        record.exc_text = None
         # convert to GCP structred logging format
         gcp_payload = self._gcp_formatter.format(record)
         return gcp_payload

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -15,6 +15,7 @@
 """Logging handler for printing formatted structured logs to standard output.
 """
 import json
+from copy import copy
 import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
@@ -59,9 +60,13 @@ class StructuredLogHandler(logging.StreamHandler):
         Returns:
             str: A JSON string formatted for GKE fluentd.
         """
+        # remove unwanted fields
+        record = copy(record)
+        record.exc_info = None
         # let other formatters alter the message
         super_payload = None
         if record.msg:
+            # format the message using default handler behaviors
             super_payload = super(StructuredLogHandler, self).format(record)
         # properly break any formatting in string to make it json safe
         record._formatted_msg = json.dumps(super_payload or "")

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -67,6 +67,7 @@ class StructuredLogHandler(logging.StreamHandler):
         # properly break any formatting in string to make it json safe
         record._formatted_msg = json.dumps(super_payload or "")
         # remove exception info to avoid duplicating it
+        # https://github.com/googleapis/python-logging/issues/382
         record.exc_info = None
         record.exc_text = None
         # convert to GCP structred logging format

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -128,12 +128,14 @@ class TestStructuredLogHandler(unittest.TestCase):
 
         handler = self._make_one()
         exception_tuple = (Exception, Exception(), None)
-        message = 'test'
-        record = logging.LogRecord(None, logging.INFO, None, None, message, None, exception_tuple)
+        message = "test"
+        record = logging.LogRecord(
+            None, logging.INFO, None, None, message, None, exception_tuple
+        )
         record.created = None
         handler.filter(record)
         result = json.loads(handler.format(record))
-        self.assertEqual(result['message'], message)
+        self.assertEqual(result["message"], message)
 
     def test_format_with_line_break(self):
         """

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -119,6 +119,24 @@ class TestStructuredLogHandler(unittest.TestCase):
         result = handler.format(record)
         self.assertIn(expected_result, result)
 
+    def test_format_with_exception(self):
+        """
+        When logging a message with an exception, the stack trace should not be appended
+        """
+        import logging
+        import json
+
+        handler = self._make_one()
+        exception_tuple = (Exception, Exception(), None)
+        message = 'test'
+        expected_result = 'test'
+        record = logging.LogRecord(None, logging.INFO, None, None, message, None, exception_tuple)
+        record.created = None
+        handler.filter(record)
+        # result = json.loads(handler.format(record))
+        result = handler.format(record)
+        self.assertIn(expected_result, result)
+
     def test_format_with_line_break(self):
         """
         When logging a message containing \n, it should be properly escaped

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -133,7 +133,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         record.created = None
         handler.filter(record)
         result = json.loads(handler.format(record))
-        self.assertEqual(result['message'], message)
+        self.assertEqual(result['message'], f"{message}\nException")
 
     def test_format_with_line_break(self):
         """

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -129,13 +129,11 @@ class TestStructuredLogHandler(unittest.TestCase):
         handler = self._make_one()
         exception_tuple = (Exception, Exception(), None)
         message = 'test'
-        expected_result = 'test'
         record = logging.LogRecord(None, logging.INFO, None, None, message, None, exception_tuple)
         record.created = None
         handler.filter(record)
-        # result = json.loads(handler.format(record))
-        result = handler.format(record)
-        self.assertIn(expected_result, result)
+        result = json.loads(handler.format(record))
+        self.assertEqual(result['message'], message)
 
     def test_format_with_line_break(self):
         """

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -135,7 +135,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         record.created = None
         handler.filter(record)
         result = json.loads(handler.format(record))
-        self.assertEqual(result['message'], f"{message}\nException")
+        self.assertEqual(result["message"], f"{message}\nException")
 
     def test_format_with_line_break(self):
         """


### PR DESCRIPTION
Previously, logging an exception with `logger.exception` would append traceback information as part of the log message, making it hard to read. This PR removes the extra exception info from the LogEntry

Fixes https://github.com/googleapis/python-logging/issues/382 🦕
