### PR TITLE
chore(docs): remove get_default_handler call from samples/snippets/handler.py

### DIFF
--- a/samples/snippets/handler.py
+++ b/samples/snippets/handler.py
@@ -28,7 +28,6 @@ def use_logging_handler():
     # you're running in and integrates the handler with the
     # Python logging module. By default this captures all logs
     # at INFO level and higher
-    client.get_default_handler()
     client.setup_logging()
     # [END logging_handler_setup]
 


### PR DESCRIPTION
Since `client.setup_logging()` calls `self.get_default_handler(**kw)` [internally](https://github.com/googleapis/python-logging/blob/ec0152c6cd9937a6e518ad5608ad5b450d43763e/google/cloud/logging_v2/client.py#L390), I don't think the call here is needed (e.g. it's not showing the users how to do something else).

Apologies, I'm currently doing this through the Github UI; I don't see how this could break tests (but that's the point of having tests) but if I need to run the tests/linter/coverage, please let me know.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #420
