### PR TITLE
chore(docs): added audit log sample to usage guide

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,9 +84,10 @@ Retrieve entries for a single logger, sorting in descending timestamp order:
     :end-before: [END logger_list_entries]
     :dedent: 4
 
-And as a practical example, retrieve all `GKE audit logs`_ from the past 24 hours:
+And as a practical example, retrieve all `GKE Admin Activity audit logs`_
+from the past 24 hours:
 
-.. _GKE audit logs: https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
+.. _GKE Admin Activity audit logs: https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
 
 .. literalinclude:: ../samples/snippets/usage_guide.py
     :start-after: [START client_list_gke_audit_logs]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -84,6 +84,14 @@ Retrieve entries for a single logger, sorting in descending timestamp order:
     :end-before: [END logger_list_entries]
     :dedent: 4
 
+And as a practical example, retrieve all `GKE audit logs`_ from the past 24 hours:
+
+.. _GKE audit logs: https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
+
+.. literalinclude:: ../samples/snippets/usage_guide.py
+    :start-after: [START client_list_gke_audit_logs]
+    :end-before: [END client_list_gke_audit_logs]
+    :dedent: 4
 
 Delete all entries for a logger
 -------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -90,8 +90,8 @@ from the past 24 hours:
 .. _GKE Admin Activity audit logs: https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
 
 .. literalinclude:: ../samples/snippets/usage_guide.py
-    :start-after: [START client_list_gke_audit_logs]
-    :end-before: [END client_list_gke_audit_logs]
+    :start-after: [START logging_list_gke_audit_logs]
+    :end-before: [END logging_list_gke_audit_logs]
     :dedent: 4
 
 Delete all entries for a logger

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -95,8 +95,8 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
     client = google.cloud.logging.Client()
     for entry in client.list_entries(filter_=filter_str):
         print(entry)
-    # [END client_list_gke_audit_logs]
-        break # we don't really need to print them all
+        # [END client_list_gke_audit_logs]
+        break  # we don't really need to print them all
 
 
 @snippet

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -71,7 +71,7 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
         # [END client_list_entries_order_by]
         break
 
-    # [START client_list_gke_audit_logs]
+    # [START logging_list_gke_audit_logs]
     import google.cloud.logging
     from datetime import datetime, timedelta, timezone
     import os
@@ -95,7 +95,7 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
     client = google.cloud.logging.Client()
     for entry in client.list_entries(filter_=filter_str):
         print(entry)
-        # [END client_list_gke_audit_logs]
+        # [END logging_list_gke_audit_logs]
         break  # we don't really need to print them all
 
 

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -83,7 +83,8 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
     # Cloud Logging expects a timestamp in RFC3339 UTC "Zulu" format
     # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
     time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
-    # build a filter that returns GKE audit Logs from the past 24 hours
+    # build a filter that returns GKE Admin Activity audit Logs from
+    # the past 24 hours
     # https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging
     filter_str = (
         f'logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity"'

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -74,25 +74,28 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
     # [START client_list_gke_audit_logs]
     import google.cloud.logging
     from datetime import datetime, timedelta, timezone
+    import os
 
-    # enter your GCP project ID
-    project_id = "your-project"
+    # pull your project id from an environment variable
+    project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
     # construct a date object representing yesterday
     yesterday = datetime.now(timezone.utc) - timedelta(days=1)
-    # Cloud Logging expects timestamps in A timestamp in RFC3339 UTC "Zulu" format
+    # Cloud Logging expects a timestamp in RFC3339 UTC "Zulu" format
     # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
     time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
-    # build a filter string that returns GKE audit Logs from the past day
-    # https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
+    # build a filter that returns GKE audit Logs from the past 24 hours
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging
     filter_str = (
-        f'logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity" '
-        f'AND timestamp>="{yesterday.strftime(time_format)}"'
+        f'logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity"'
+        f' AND resource.type="k8s_cluster"'
+        f' AND timestamp>="{yesterday.strftime(time_format)}"'
     )
     # query and print all matching logs
     client = google.cloud.logging.Client()
     for entry in client.list_entries(filter_=filter_str):
         print(entry)
     # [END client_list_gke_audit_logs]
+        break # we don't really need to print them all
 
 
 @snippet

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -71,6 +71,29 @@ def client_list_entries(client, to_delete):  # pylint: disable=unused-argument
         # [END client_list_entries_order_by]
         break
 
+    # [START client_list_gke_audit_logs]
+    import google.cloud.logging
+    from datetime import datetime, timedelta, timezone
+
+    # enter your GCP project ID
+    project_id = "your-project"
+    # construct a date object representing yesterday
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+    # Cloud Logging expects timestamps in A timestamp in RFC3339 UTC "Zulu" format
+    # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+    time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
+    # build a filter string that returns GKE audit Logs from the past day
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging#audit_logs_in_your_project
+    filter_str = (
+        f'logName="projects/{project_id}/logs/cloudaudit.googleapis.com%2Factivity" '
+        f'AND timestamp>="{yesterday.strftime(time_format)}"'
+    )
+    # query and print all matching logs
+    client = google.cloud.logging.Client()
+    for entry in client.list_entries(filter_=filter_str):
+        print(entry)
+    # [END client_list_gke_audit_logs]
+
 
 @snippet
 def logger_usage(client, to_delete):


### PR DESCRIPTION
Added a new code sample showing how to query and print GKE Audit logs

Screenshot taken from locally rendered update to the [usage guide](https://googleapis.dev/python/logging/latest/usage.html#retrieving-log-entries), to show how it will look in context:

![image](https://user-images.githubusercontent.com/3914119/138188015-d661356a-e12c-48e8-aa8e-55f1c9d32f9d.png)


Fixes https://github.com/googleapis/python-logging/issues/427 🦕
