### PR TITLE
feat: use structured logging on GCF with python 3.7

### DIFF
--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -357,7 +357,7 @@ class Client(ClientWithProject):
                 return ContainerEngineHandler(**kw)
             elif monitored_resource.type == _GCF_RESOURCE_TYPE:
                 # __stdout__ stream required to support structured logging on Python 3.7
-                kw["stream"] = sys.__stdout__
+                kw["stream"] = kw.get("stream", sys.__stdout__)
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import sys
 
 try:
     from google.cloud.logging_v2 import _gapic
@@ -355,13 +354,7 @@ class Client(ClientWithProject):
                 return AppEngineHandler(self, **kw)
             elif monitored_resource.type == _GKE_RESOURCE_TYPE:
                 return ContainerEngineHandler(**kw)
-            elif (
-                monitored_resource.type == _GCF_RESOURCE_TYPE
-                and sys.version_info[0] == 3
-                and sys.version_info[1] >= 8
-            ):
-                # Cloud Functions with runtimes > 3.8 supports structured logs on standard out
-                # 3.7 should use the standard CloudLoggingHandler, which sends logs over the network.
+            elif monitored_resource.type == _GCF_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import sys
 
 try:
     from google.cloud.logging_v2 import _gapic
@@ -355,6 +356,8 @@ class Client(ClientWithProject):
             elif monitored_resource.type == _GKE_RESOURCE_TYPE:
                 return ContainerEngineHandler(**kw)
             elif monitored_resource.type == _GCF_RESOURCE_TYPE:
+                # __stdout__ stream required to support structured logging on Python 3.7
+                kw["stream"] = sys.__stdout__
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)


### PR DESCRIPTION
Previously, GCF Python 3.7 didn't support structured logging, so the library would default to the grpc CloudLoggingHandler. now that the environment supports structured logging, we can update to the StructuredLoggingHandler to make it in line with other serverless environments
