### PR TITLE
fix: allow non-project resources when parsing entries

### DIFF
--- a/google/cloud/logging_v2/entries.py
+++ b/google/cloud/logging_v2/entries.py
@@ -49,6 +49,7 @@ _LOGGER_TEMPLATE = re.compile(
 def logger_name_from_path(path):
     """Validate a logger URI path and get the logger name.
     Path should be one of the following formats:
+
         "projects/[PROJECT_ID]/logs/[NAME]"
         "organizations/[ORGANIZATION_ID]/logs/[NAME]"
         "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[NAME]"

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -80,8 +80,6 @@ class Test_logger_name_from_path(unittest.TestCase):
         self.assertEqual(logger_name, LOGGER_NAME)
 
     def test_invalid_inputs(self):
-        LOGGER_NAME = "LOGGER_NAME"
-        PROJECT = "my-folder-1234"
         invalid_list = [
             "",
             "abc/123/logs/456",

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -23,20 +23,79 @@ class Test_logger_name_from_path(unittest.TestCase):
 
         return logger_name_from_path(path)
 
-    def test_w_simple_name(self):
+    def test_project_w_simple_name(self):
         LOGGER_NAME = "LOGGER_NAME"
         PROJECT = "my-project-1234"
         PATH = "projects/%s/logs/%s" % (PROJECT, LOGGER_NAME)
         logger_name = self._call_fut(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
 
-    def test_w_name_w_all_extras(self):
+    def test_project_w_name_w_all_extras(self):
         LOGGER_NAME = "LOGGER_NAME-part.one~part.two%part-three"
         PROJECT = "my-project-1234"
         PATH = "projects/%s/logs/%s" % (PROJECT, LOGGER_NAME)
         logger_name = self._call_fut(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
 
+    def test_org_w_simple_name(self):
+        LOGGER_NAME = "LOGGER_NAME"
+        ORG = "my-org-1234"
+        PATH = "organizations/%s/logs/%s" % (ORG, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_org_w_name_w_all_extras(self):
+        LOGGER_NAME = "LOGGER_NAME-part.one~part.two%part-three"
+        ORG = "my-org-1234"
+        PATH = "organizations/%s/logs/%s" % (ORG, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_billing_acct_w_simple_name(self):
+        LOGGER_NAME = "LOGGER_NAME"
+        ID = "my-bill-acct-1234"
+        PATH = "billingAccounts/%s/logs/%s" % (ID, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_billing_acct_w_name_w_all_extras(self):
+        LOGGER_NAME = "LOGGER_NAME-part.one~part.two%part-three"
+        ID = "my-bill-acct-1234"
+        PATH = "billingAccounts/%s/logs/%s" % (ID, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_folder_w_simple_name(self):
+        LOGGER_NAME = "LOGGER_NAME"
+        ID = "my-folder-1234"
+        PATH = "folders/%s/logs/%s" % (ID, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_folder_w_name_w_all_extras(self):
+        LOGGER_NAME = "LOGGER_NAME-part.one~part.two%part-three"
+        ID = "my-folder-1234"
+        PATH = "folders/%s/logs/%s" % (ID, LOGGER_NAME)
+        logger_name = self._call_fut(PATH)
+        self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_invalid_inputs(self):
+        LOGGER_NAME = "LOGGER_NAME"
+        PROJECT = "my-folder-1234"
+        invalid_list = [
+            "",
+            "abc/123/logs/456",
+            "projects//logs/",
+            "projects/123/logs",
+            "projects/123logs/",
+            "projects123/logs",
+            "project/123",
+            "projects123logs456",
+            "/logs/123"
+        ]
+        for path in invalid_list:
+            with self.assertRaises(ValueError):
+                self._call_fut(path)
 
 class Test__int_or_none(unittest.TestCase):
     def _call_fut(self, value):

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -91,11 +91,12 @@ class Test_logger_name_from_path(unittest.TestCase):
             "projects123/logs",
             "project/123",
             "projects123logs456",
-            "/logs/123"
+            "/logs/123",
         ]
         for path in invalid_list:
             with self.assertRaises(ValueError):
                 self._call_fut(path)
+
 
 class Test__int_or_none(unittest.TestCase):
     def _call_fut(self, value):


### PR DESCRIPTION
Previously, the entry-parsing code assumed all logs originated from a specific project, when they could originate from a `folder`, `organization`, or `billingAccount`. This PR changes the regex check to be more permissive, and adds extra test cases

Fixes https://github.com/googleapis/python-logging/issues/399 🦕
