### PR TITLE
fix: allow reading logs from non-project paths

### DIFF
--- a/google/cloud/logging_v2/entries.py
+++ b/google/cloud/logging_v2/entries.py
@@ -46,11 +46,12 @@ _LOGGER_TEMPLATE = re.compile(
 )
 
 
-def logger_name_from_path(path):
+def logger_name_from_path(path, project=None):
     """Validate a logger URI path and get the logger name.
 
     Args:
         path (str): URI path for a logger API request
+        project (str): The project the path is expected to belong to
 
     Returns:
         str: Logger name parsed from ``path``.
@@ -59,7 +60,7 @@ def logger_name_from_path(path):
         ValueError: If the ``path`` is ill-formed of if the project
             from ``path`` does not agree with the ``project`` passed in.
     """
-    return _name_from_project_path(path, None, _LOGGER_TEMPLATE)
+    return _name_from_project_path(path, project, _LOGGER_TEMPLATE)
 
 
 def _int_or_none(value):
@@ -165,8 +166,13 @@ class LogEntry(_LogEntryTuple):
         logger_fullname = resource["logName"]
         logger = loggers.get(logger_fullname)
         if logger is None:
-            logger_name = logger_name_from_path(logger_fullname)
-            logger = loggers[logger_fullname] = client.logger(logger_name)
+            # attempt to create a logger if possible
+            try:
+                logger_name = logger_name_from_path(logger_fullname, client.project)
+                logger = loggers[logger_fullname] = client.logger(logger_name)
+            except ValueError:
+                # log name is not scoped to a project. Leave logger as None
+                pass
         payload = cls._extract_payload(resource)
         insert_id = resource.get("insertId")
         timestamp = resource.get("timestamp")

--- a/google/cloud/logging_v2/entries.py
+++ b/google/cloud/logging_v2/entries.py
@@ -156,7 +156,8 @@ class LogEntry(_LogEntryTuple):
                 Client which holds credentials and project configuration.
             loggers (Optional[dict]):
                 A mapping of logger fullnames -> loggers.  If not
-                passed, the entry will have a newly-created logger.
+                passed, the entry will have a newly-created logger if possible,
+                or an empty logger field if not.
 
         Returns:
             google.cloud.logging.entries.LogEntry: Log entry parsed from ``resource``.

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -18,10 +18,10 @@ import mock
 
 
 class Test_logger_name_from_path(unittest.TestCase):
-    def _call_fut(self, path):
+    def _call_fut(self, path, project=None):
         from google.cloud.logging_v2.entries import logger_name_from_path
 
-        return logger_name_from_path(path)
+        return logger_name_from_path(path, project)
 
     def test_w_simple_name(self):
         LOGGER_NAME = "LOGGER_NAME"
@@ -36,6 +36,30 @@ class Test_logger_name_from_path(unittest.TestCase):
         PATH = "projects/%s/logs/%s" % (PROJECT, LOGGER_NAME)
         logger_name = self._call_fut(PATH)
         self.assertEqual(logger_name, LOGGER_NAME)
+
+    def test_w_wrong_project(self):
+        LOGGER_NAME = "LOGGER_NAME"
+        IN_PROJECT = "in-project"
+        PATH_PROJECT = "path-project"
+        PATH = "projects/%s/logs/%s" % (PATH_PROJECT, LOGGER_NAME)
+        with self.assertRaises(ValueError):
+            logger_name = self._call_fut(PATH, IN_PROJECT)
+
+    def test_invalid_inputs(self):
+        invalid_list = [
+            "",
+            "abc/123/logs/456",
+            "projects//logs/",
+            "projects/123/logs",
+            "projects/123logs/",
+            "projects123/logs",
+            "project/123",
+            "projects123logs456",
+            "/logs/123",
+        ]
+        for path in invalid_list:
+            with self.assertRaises(ValueError):
+                self._call_fut(path)
 
 
 class Test__int_or_none(unittest.TestCase):
@@ -299,6 +323,63 @@ class TestLogEntry(unittest.TestCase):
 
         self.assertEqual(entry.log_name, LOG_NAME)
         self.assertIs(entry.logger, LOGGER)
+        self.assertEqual(entry.insert_id, IID)
+        self.assertEqual(entry.timestamp, NOW)
+        self.assertEqual(entry.received_timestamp, LATER)
+        self.assertEqual(entry.labels, LABELS)
+        self.assertEqual(entry.trace, TRACE)
+        self.assertEqual(entry.span_id, SPANID)
+        self.assertTrue(entry.trace_sampled)
+
+        source_location = entry.source_location
+        self.assertEqual(source_location["file"], FILE)
+        self.assertEqual(source_location["line"], LINE_NO)
+        self.assertEqual(source_location["function"], FUNCTION)
+
+        self.assertEqual(entry.operation, OPERATION)
+        self.assertIsNone(entry.payload)
+
+    def test_from_api_repr_w_folder_path(self):
+        from datetime import datetime
+        from datetime import timedelta
+        from google.cloud._helpers import UTC
+
+        client = _Client(self.PROJECT)
+        IID = "IID"
+        NOW = datetime.utcnow().replace(tzinfo=UTC)
+        LATER = NOW + timedelta(seconds=1)
+        TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
+        RECEIVED = _datetime_to_rfc3339_w_nanos(LATER)
+        LOG_NAME = "folders/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME)
+        LABELS = {"foo": "bar", "baz": "qux"}
+        TRACE = "12345678-1234-5678-1234-567812345678"
+        SPANID = "000000000000004a"
+        FILE = "my_file.py"
+        LINE_NO = 123
+        FUNCTION = "my_function"
+        SOURCE_LOCATION = {"file": FILE, "line": str(LINE_NO), "function": FUNCTION}
+        OP_ID = "OP_ID"
+        PRODUCER = "PRODUCER"
+        OPERATION = {"id": OP_ID, "producer": PRODUCER, "first": True, "last": False}
+        API_REPR = {
+            "logName": LOG_NAME,
+            "insertId": IID,
+            "timestamp": TIMESTAMP,
+            "receiveTimestamp": RECEIVED,
+            "labels": LABELS,
+            "trace": TRACE,
+            "spanId": SPANID,
+            "traceSampled": True,
+            "sourceLocation": SOURCE_LOCATION,
+            "operation": OPERATION,
+        }
+        LOGGER = object()
+        klass = self._get_target_class()
+
+        entry = klass.from_api_repr(API_REPR, client)
+
+        self.assertEqual(entry.log_name, LOG_NAME)
+        self.assertIsNone(entry.logger)
         self.assertEqual(entry.insert_id, IID)
         self.assertEqual(entry.timestamp, NOW)
         self.assertEqual(entry.received_timestamp, LATER)

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -43,7 +43,7 @@ class Test_logger_name_from_path(unittest.TestCase):
         PATH_PROJECT = "path-project"
         PATH = "projects/%s/logs/%s" % (PATH_PROJECT, LOGGER_NAME)
         with self.assertRaises(ValueError):
-            logger_name = self._call_fut(PATH, IN_PROJECT)
+            self._call_fut(PATH, IN_PROJECT)
 
     def test_invalid_inputs(self):
         invalid_list = [
@@ -373,7 +373,6 @@ class TestLogEntry(unittest.TestCase):
             "sourceLocation": SOURCE_LOCATION,
             "operation": OPERATION,
         }
-        LOGGER = object()
         klass = self._get_target_class()
 
         entry = klass.from_api_repr(API_REPR, client)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -939,15 +939,13 @@ class TestLogger(unittest.TestCase):
 
     def test_list_entries_folder(self):
         from google.cloud.logging import TextEntry
-        from google.cloud.logging import Logger
         from google.cloud.logging import Client
-
 
         client = Client(
             project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
         )
         FOLDER_ID = "123"
-        LOG_NAME= f"folders/{FOLDER_ID}/logs/cloudaudit.googleapis.com%2Fdata_access"
+        LOG_NAME = f"folders/{FOLDER_ID}/logs/cloudaudit.googleapis.com%2Fdata_access"
 
         ENTRIES = [
             {
@@ -960,9 +958,7 @@ class TestLogger(unittest.TestCase):
         returned = {"entries": ENTRIES}
         client._connection = _Connection(returned)
 
-        iterator = client.list_entries(
-            resource_names=[f"folder/{FOLDER_ID}"],
-        )
+        iterator = client.list_entries(resource_names=[f"folder/{FOLDER_ID}"],)
         entries = list(iterator)
         # Check the entries.
         self.assertEqual(len(entries), 1)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -937,6 +937,40 @@ class TestLogger(unittest.TestCase):
             },
         )
 
+    def test_list_entries_folder(self):
+        from google.cloud.logging import TextEntry
+        from google.cloud.logging import Logger
+        from google.cloud.logging import Client
+
+
+        client = Client(
+            project=self.PROJECT, credentials=_make_credentials(), _use_grpc=False
+        )
+        FOLDER_ID = "123"
+        LOG_NAME= f"folders/{FOLDER_ID}/logs/cloudaudit.googleapis.com%2Fdata_access"
+
+        ENTRIES = [
+            {
+                "textPayload": "hello world",
+                "insertId": "1",
+                "resource": {"type": "global"},
+                "logName": LOG_NAME,
+            },
+        ]
+        returned = {"entries": ENTRIES}
+        client._connection = _Connection(returned)
+
+        iterator = client.list_entries(
+            resource_names=[f"folder/{FOLDER_ID}"],
+        )
+        entries = list(iterator)
+        # Check the entries.
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertIsInstance(entry, TextEntry)
+        self.assertIsNone(entry.logger)
+        self.assertEqual(entry.log_name, LOG_NAME)
+
 
 class TestBatch(unittest.TestCase):
 


### PR DESCRIPTION
Previously, the entry-parsing code assumed all logs originated from a project, but the list_logs API allows reading from folders, organizations, and billingIds as well. If a user attempted to read from one of these non-project paths, the library would fail to build the LogEntry object and crash. This PR fixes that issue, and is more forgiving in its entry parsing logic.

Now, if a log is found with a parent path that does not represent the active project, the `entry.logger` field will be `None`.

Fixes #399 
