### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "logging",
     "name_pretty": "Cloud Logging",
     "product_documentation": "https://cloud.google.com/logging/docs",
-    "client_documentation": "https://googleapis.dev/python/logging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/logging/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Logging configuration.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
    :target: https://pypi.org/project/google-cloud-logging/
 .. _Cloud Logging API: https://cloud.google.com/logging
-.. _Client Library Documentation: https://googleapis.dev/python/logging/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/logging/latest
 .. _Product Documentation:  https://cloud.google.com/logging/docs
 .. _Setting Up Cloud Logging for Python: https://cloud.google.com/logging/docs/setup/python
 .. _Python's standard logging library: https://docs.python.org/2/library/logging.html


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.