### PR TITLE
chore: enable staleness and pull request size bots on repository

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -1,0 +1,7 @@
+product: true
+requestsize:
+  enabled: true
+staleness:
+  pullrequest: true
+  old: 30
+  extraold: 60


### PR DESCRIPTION
Enable staleness and pull request size auto-label bots on this repository
