### PR TITLE
fix: remove unnecessary detect_resource calls from CloudLoggingHandler

### DIFF
--- a/google/cloud/logging_v2/_helpers.py
+++ b/google/cloud/logging_v2/_helpers.py
@@ -99,6 +99,7 @@ def retrieve_metadata_server(metadata_key, timeout=5):
             Key of the metadata which will form the url. You can
             also supply query parameters after the metadata key.
             e.g. "tags?alt=json"
+        timeout (number): number of seconds to wait for the HTTP request
 
     Returns:
         str: The value of the metadata key returned by the metadata server.

--- a/google/cloud/logging_v2/_helpers.py
+++ b/google/cloud/logging_v2/_helpers.py
@@ -89,7 +89,7 @@ def entry_from_resource(resource, client, loggers):
     return LogEntry.from_api_repr(resource, client, loggers=loggers)
 
 
-def retrieve_metadata_server(metadata_key):
+def retrieve_metadata_server(metadata_key, timeout=5):
     """Retrieve the metadata key in the metadata server.
 
     See: https://cloud.google.com/compute/docs/storing-retrieving-metadata
@@ -106,7 +106,7 @@ def retrieve_metadata_server(metadata_key):
     url = METADATA_URL + metadata_key
 
     try:
-        response = requests.get(url, headers=METADATA_HEADERS)
+        response = requests.get(url, headers=METADATA_HEADERS, timeout=timeout)
 
         if response.status_code == requests.codes.ok:
             return response.text

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -179,7 +179,7 @@ class CloudLoggingHandler(logging.StreamHandler):
             resource = detect_resource(client.project)
         self.name = name
         self.client = client
-        self.transport = transport(client, name)
+        self.transport = transport(client, name, resource=resource)
         self.project_id = client.project
         self.resource = resource
         self.labels = labels

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -261,7 +261,7 @@ class BackgroundThreadTransport(Transport):
         grace_period=_DEFAULT_GRACE_PERIOD,
         batch_size=_DEFAULT_MAX_BATCH_SIZE,
         max_latency=_DEFAULT_MAX_LATENCY,
-        resource=_GLOBAL_RESOURCE
+        resource=_GLOBAL_RESOURCE,
         **kwargs,
     ):
         """

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -261,8 +261,7 @@ class BackgroundThreadTransport(Transport):
         grace_period=_DEFAULT_GRACE_PERIOD,
         batch_size=_DEFAULT_MAX_BATCH_SIZE,
         max_latency=_DEFAULT_MAX_LATENCY,
-        resource=_GLOBAL_RESOURCE
-        **kwargs,
+        resource=_GLOBAL_RESOURCE ** kwargs,
     ):
         """
         Args:

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -278,7 +278,7 @@ class BackgroundThreadTransport(Transport):
                 than the grace_period. This means this is effectively the longest
                 amount of time the background thread will hold onto log entries
                 before sending them to the server.
-            resource (Optional[Resource|dict]): The default monitored resource to associate 
+            resource (Optional[Resource|dict]): The default monitored resource to associate
                 with logs when not specified
         """
         self.client = client

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -29,6 +29,7 @@ import time
 
 from google.cloud.logging_v2 import _helpers
 from google.cloud.logging_v2.handlers.transports.base import Transport
+from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 
 _DEFAULT_GRACE_PERIOD = 5.0  # Seconds
 _DEFAULT_MAX_BATCH_SIZE = 10
@@ -260,6 +261,8 @@ class BackgroundThreadTransport(Transport):
         grace_period=_DEFAULT_GRACE_PERIOD,
         batch_size=_DEFAULT_MAX_BATCH_SIZE,
         max_latency=_DEFAULT_MAX_LATENCY,
+        resource=_GLOBAL_RESOURCE
+        **kwargs,
     ):
         """
         Args:
@@ -275,9 +278,11 @@ class BackgroundThreadTransport(Transport):
                 than the grace_period. This means this is effectively the longest
                 amount of time the background thread will hold onto log entries
                 before sending them to the server.
+            resource (Optional[Resource|dict]): The default monitored resource to associate 
+                with logs when not specified
         """
         self.client = client
-        logger = self.client.logger(name)
+        logger = self.client.logger(name, resource=resource)
         self.worker = _Worker(
             logger,
             grace_period=grace_period,

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -14,6 +14,7 @@
 
 """Module containing base class for logging transport."""
 
+from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 
 class Transport(object):
     """Base class for Google Cloud Logging handler transports.
@@ -21,6 +22,17 @@ class Transport(object):
     Subclasses of :class:`Transport` must have constructors that accept a
     client and name object, and must override :meth:`send`.
     """
+
+    def __init__(self, client, name, resource=_GLOBAL_RESOURCE, **kwargs):
+        """
+        Args:
+            client (~logging_v2.client.Client):
+                The Logging client.
+            name (str): The name of the lgoger.
+            resource (Optional[Resource|dict]): The default monitored resource to associate 
+                with logs when not specified
+        """
+        raise NotImplementedError
 
     def send(self, record, message, **kwargs):
         """Transport send to be implemented by subclasses.

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -30,7 +30,7 @@ class Transport(object):
             client (~logging_v2.client.Client):
                 The Logging client.
             name (str): The name of the lgoger.
-            resource (Optional[Resource|dict]): The default monitored resource to associate 
+            resource (Optional[Resource|dict]): The default monitored resource to associate
                 with logs when not specified
         """
         super().__init__()

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -16,6 +16,7 @@
 
 from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 
+
 class Transport(object):
     """Base class for Google Cloud Logging handler transports.
 

--- a/google/cloud/logging_v2/handlers/transports/base.py
+++ b/google/cloud/logging_v2/handlers/transports/base.py
@@ -33,7 +33,7 @@ class Transport(object):
             resource (Optional[Resource|dict]): The default monitored resource to associate 
                 with logs when not specified
         """
-        raise NotImplementedError
+        super().__init__()
 
     def send(self, record, message, **kwargs):
         """Transport send to be implemented by subclasses.

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -33,7 +33,7 @@ class SyncTransport(Transport):
             client (~logging_v2.client.Client):
                 The Logging client.
             name (str): The name of the lgoger.
-            resource (Optional[Resource|dict]): The default monitored resource to associate 
+            resource (Optional[Resource|dict]): The default monitored resource to associate
                 with logs when not specified
         """
         self.logger = client.logger(name, resource=resource)

--- a/google/cloud/logging_v2/handlers/transports/sync.py
+++ b/google/cloud/logging_v2/handlers/transports/sync.py
@@ -18,6 +18,7 @@ Logs directly to the the Cloud Logging API with a synchronous call.
 """
 from google.cloud.logging_v2 import _helpers
 from google.cloud.logging_v2.handlers.transports.base import Transport
+from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 
 
 class SyncTransport(Transport):
@@ -26,8 +27,16 @@ class SyncTransport(Transport):
     Uses this library's Logging client to directly make the API call.
     """
 
-    def __init__(self, client, name):
-        self.logger = client.logger(name)
+    def __init__(self, client, name, resource=_GLOBAL_RESOURCE, **kwargs):
+        """
+        Args:
+            client (~logging_v2.client.Client):
+                The Logging client.
+            name (str): The name of the lgoger.
+            resource (Optional[Resource|dict]): The default monitored resource to associate 
+                with logs when not specified
+        """
+        self.logger = client.logger(name, resource=resource)
 
     def send(self, record, message, **kwargs):
         """Overrides transport.send().

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -860,7 +860,7 @@ class _Client(object):
 
 
 class _Transport(object):
-    def __init__(self, client, name):
+    def __init__(self, client, name, resource=None):
         self.client = client
         self.name = name
 

--- a/tests/unit/handlers/transports/test_background_thread.py
+++ b/tests/unit/handlers/transports/test_background_thread.py
@@ -509,11 +509,12 @@ class _RaisingBatch(_Batch):
 
 
 class _Logger(object):
-    def __init__(self, name):
+    def __init__(self, name, resource=None):
         self.name = name
         self._batch_cls = _Batch
         self._batch = None
         self._num_batches = 0
+        self.resource = resource
 
     def batch(self):
         self._batch = self._batch_cls()
@@ -530,6 +531,6 @@ class _Client(object):
         self._credentials = credentials
         self._connection = mock.Mock(credentials=credentials, spec=["credentials"])
 
-    def logger(self, name):  # pylint: disable=unused-argument
-        self._logger = _Logger(name)
+    def logger(self, name, resource=None):  # pylint: disable=unused-argument
+        self._logger = _Logger(name, resource=resource)
         return self._logger

--- a/tests/unit/handlers/transports/test_base.py
+++ b/tests/unit/handlers/transports/test_base.py
@@ -29,10 +29,13 @@ class TestBaseHandler(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_send_is_abstract(self):
-        target = self._make_one()
+        target = self._make_one("client", "name")
         with self.assertRaises(NotImplementedError):
             target.send(None, None, resource=None)
 
+    def test_resource_is_valid_argunent(self):
+        self._make_one("client", "name", resource="resource")
+
     def test_flush_is_abstract_and_optional(self):
-        target = self._make_one()
+        target = self._make_one("client", "name")
         target.flush()

--- a/tests/unit/handlers/transports/test_sync.py
+++ b/tests/unit/handlers/transports/test_sync.py
@@ -91,8 +91,9 @@ class TestSyncHandler(unittest.TestCase):
 class _Logger(object):
     from google.cloud.logging_v2.logger import _GLOBAL_RESOURCE
 
-    def __init__(self, name):
+    def __init__(self, name, resource=_GLOBAL_RESOURCE):
         self.name = name
+        self.resource = resource
 
     def log(
         self,
@@ -119,8 +120,8 @@ class _Client(object):
     def __init__(self, project):
         self.project = project
 
-    def logger(self, name):  # pylint: disable=unused-argument
-        self._logger = _Logger(name)
+    def logger(self, name, resource=None):  # pylint: disable=unused-argument
+        self._logger = _Logger(name, resource=resource)
         return self._logger
 
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-logging/issues/475

Previously, CLoudLoggingHandler would always call `detect_resource`, even when a resource is passed in. This was because the handler class wasn't sending the resource to the Transport class, so it would create a new logger that would have to re-detect the resource before usage (even though the resource field will be set by handlers in this case).

This PR fixes the issue by adding an optional `resource` argument to the transport classes, and making CloudLoggingHandler populate the field.

This PR also adds a timeout to detect_resource to prevent similar issues in the future.