### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-logging"
-copyright = u"2019, Google"
-author = u"Google APIs"
+project = "google-cloud-logging"
+copyright = "2019, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -261,7 +261,7 @@ latex_documents = [
     (
         master_doc,
         "google-cloud-logging.tex",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "manual",
     )
@@ -296,7 +296,7 @@ man_pages = [
     (
         master_doc,
         "google-cloud-logging",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         [author],
         1,
     )
@@ -315,7 +315,7 @@ texinfo_documents = [
     (
         master_doc,
         "google-cloud-logging",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "google-cloud-logging",
         "google-cloud-logging Library",
@@ -340,7 +340,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("http://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.io/grpc/python/", None),
 }
 

--- a/google/cloud/logging/entries.py
+++ b/google/cloud/logging/entries.py
@@ -232,8 +232,7 @@ class LogEntry(_LogEntryTuple):
         return inst
 
     def to_api_repr(self):
-        """API repr (JSON format) for entry.
-        """
+        """API repr (JSON format) for entry."""
         info = {}
         if self.log_name is not None:
             info["logName"] = self.log_name
@@ -285,8 +284,7 @@ class TextEntry(LogEntry):
         return resource["textPayload"]
 
     def to_api_repr(self):
-        """API repr (JSON format) for entry.
-        """
+        """API repr (JSON format) for entry."""
         info = super(TextEntry, self).to_api_repr()
         info["textPayload"] = self.payload
         return info
@@ -313,8 +311,7 @@ class StructEntry(LogEntry):
         return resource["jsonPayload"]
 
     def to_api_repr(self):
-        """API repr (JSON format) for entry.
-        """
+        """API repr (JSON format) for entry."""
         info = super(StructEntry, self).to_api_repr()
         info["jsonPayload"] = self.payload
         return info
@@ -351,8 +348,7 @@ class ProtobufEntry(LogEntry):
             return self.payload
 
     def to_api_repr(self):
-        """API repr (JSON format) for entry.
-        """
+        """API repr (JSON format) for entry."""
         info = super(ProtobufEntry, self).to_api_repr()
         info["protoPayload"] = MessageToDict(self.payload)
         return info

--- a/google/cloud/logging/handlers/_helpers.py
+++ b/google/cloud/logging/handlers/_helpers.py
@@ -41,8 +41,8 @@ _WEBAPP2_TRACE_HEADER = "X-CLOUD-TRACE-CONTEXT"
 def format_stackdriver_json(record, message):
     """Helper to format a LogRecord in in Stackdriver fluentd format.
 
-        :rtype: str
-        :returns: JSON str to be written to the log file.
+    :rtype: str
+    :returns: JSON str to be written to the log file.
     """
     subsecond, second = math.modf(record.created)
 

--- a/google/cloud/logging/logger.py
+++ b/google/cloud/logging/logger.py
@@ -114,8 +114,7 @@ class Logger(object):
         return Batch(self, client)
 
     def _do_log(self, client, _entry_class, payload=None, **kw):
-        """Helper for :meth:`log_empty`, :meth:`log_text`, etc.
-        """
+        """Helper for :meth:`log_empty`, :meth:`log_text`, etc."""
         client = self._require_client(client)
 
         # Apply defaults

--- a/google/cloud/logging_v2/gapic/config_service_v2_client.py
+++ b/google/cloud/logging_v2/gapic/config_service_v2_client.py
@@ -40,7 +40,9 @@ from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 
 
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution("google-cloud-logging",).version
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    "google-cloud-logging",
+).version
 
 
 class ConfigServiceV2Client(object):
@@ -77,7 +79,8 @@ class ConfigServiceV2Client(object):
     def billing_path(cls, billing_account):
         """Return a fully-qualified billing string."""
         return google.api_core.path_template.expand(
-            "billingAccounts/{billing_account}", billing_account=billing_account,
+            "billingAccounts/{billing_account}",
+            billing_account=billing_account,
         )
 
     @classmethod
@@ -110,7 +113,10 @@ class ConfigServiceV2Client(object):
     @classmethod
     def folder_path(cls, folder):
         """Return a fully-qualified folder string."""
-        return google.api_core.path_template.expand("folders/{folder}", folder=folder,)
+        return google.api_core.path_template.expand(
+            "folders/{folder}",
+            folder=folder,
+        )
 
     @classmethod
     def folder_exclusion_path(cls, folder, exclusion):
@@ -125,14 +131,17 @@ class ConfigServiceV2Client(object):
     def folder_sink_path(cls, folder, sink):
         """Return a fully-qualified folder_sink string."""
         return google.api_core.path_template.expand(
-            "folders/{folder}/sinks/{sink}", folder=folder, sink=sink,
+            "folders/{folder}/sinks/{sink}",
+            folder=folder,
+            sink=sink,
         )
 
     @classmethod
     def organization_path(cls, organization):
         """Return a fully-qualified organization string."""
         return google.api_core.path_template.expand(
-            "organizations/{organization}", organization=organization,
+            "organizations/{organization}",
+            organization=organization,
         )
 
     @classmethod
@@ -157,14 +166,17 @@ class ConfigServiceV2Client(object):
     def project_path(cls, project):
         """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
-            "projects/{project}", project=project,
+            "projects/{project}",
+            project=project,
         )
 
     @classmethod
     def sink_path(cls, project, sink):
         """Return a fully-qualified sink string."""
         return google.api_core.path_template.expand(
-            "projects/{project}/sinks/{sink}", project=project, sink=sink,
+            "projects/{project}/sinks/{sink}",
+            project=project,
+            sink=sink,
         )
 
     def __init__(
@@ -253,8 +265,12 @@ class ConfigServiceV2Client(object):
                     )
                 self.transport = transport
         else:
-            self.transport = config_service_v2_grpc_transport.ConfigServiceV2GrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials,
+            self.transport = (
+                config_service_v2_grpc_transport.ConfigServiceV2GrpcTransport(
+                    address=api_endpoint,
+                    channel=channel,
+                    credentials=credentials,
+                )
             )
 
         if client_info is None:
@@ -360,7 +376,8 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.ListSinksRequest(
-            parent=parent, page_size=page_size,
+            parent=parent,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []
@@ -450,7 +467,9 @@ class ConfigServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_config_pb2.GetSinkRequest(sink_name=sink_name,)
+        request = logging_config_pb2.GetSinkRequest(
+            sink_name=sink_name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -554,7 +573,9 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.CreateSinkRequest(
-            parent=parent, sink=sink, unique_writer_identity=unique_writer_identity,
+            parent=parent,
+            sink=sink,
+            unique_writer_identity=unique_writer_identity,
         )
         if metadata is None:
             metadata = []
@@ -759,7 +780,9 @@ class ConfigServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_config_pb2.DeleteSinkRequest(sink_name=sink_name,)
+        request = logging_config_pb2.DeleteSinkRequest(
+            sink_name=sink_name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -857,7 +880,8 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.ListExclusionsRequest(
-            parent=parent, page_size=page_size,
+            parent=parent,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []
@@ -947,7 +971,9 @@ class ConfigServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_config_pb2.GetExclusionRequest(name=name,)
+        request = logging_config_pb2.GetExclusionRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -1038,7 +1064,8 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.CreateExclusionRequest(
-            parent=parent, exclusion=exclusion,
+            parent=parent,
+            exclusion=exclusion,
         )
         if metadata is None:
             metadata = []
@@ -1142,7 +1169,9 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.UpdateExclusionRequest(
-            name=name, exclusion=exclusion, update_mask=update_mask,
+            name=name,
+            exclusion=exclusion,
+            update_mask=update_mask,
         )
         if metadata is None:
             metadata = []
@@ -1218,7 +1247,9 @@ class ConfigServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_config_pb2.DeleteExclusionRequest(name=name,)
+        request = logging_config_pb2.DeleteExclusionRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -1306,7 +1337,9 @@ class ConfigServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_config_pb2.GetCmekSettingsRequest(name=name,)
+        request = logging_config_pb2.GetCmekSettingsRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -1422,7 +1455,9 @@ class ConfigServiceV2Client(object):
             )
 
         request = logging_config_pb2.UpdateCmekSettingsRequest(
-            name=name, cmek_settings=cmek_settings, update_mask=update_mask,
+            name=name,
+            cmek_settings=cmek_settings,
+            update_mask=update_mask,
         )
         if metadata is None:
             metadata = []

--- a/google/cloud/logging_v2/gapic/logging_service_v2_client.py
+++ b/google/cloud/logging_v2/gapic/logging_service_v2_client.py
@@ -44,7 +44,9 @@ from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 
 
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution("google-cloud-logging",).version
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    "google-cloud-logging",
+).version
 
 
 class LoggingServiceV2Client(object):
@@ -81,7 +83,8 @@ class LoggingServiceV2Client(object):
     def billing_path(cls, billing_account):
         """Return a fully-qualified billing string."""
         return google.api_core.path_template.expand(
-            "billingAccounts/{billing_account}", billing_account=billing_account,
+            "billingAccounts/{billing_account}",
+            billing_account=billing_account,
         )
 
     @classmethod
@@ -96,27 +99,35 @@ class LoggingServiceV2Client(object):
     @classmethod
     def folder_path(cls, folder):
         """Return a fully-qualified folder string."""
-        return google.api_core.path_template.expand("folders/{folder}", folder=folder,)
+        return google.api_core.path_template.expand(
+            "folders/{folder}",
+            folder=folder,
+        )
 
     @classmethod
     def folder_log_path(cls, folder, log):
         """Return a fully-qualified folder_log string."""
         return google.api_core.path_template.expand(
-            "folders/{folder}/logs/{log}", folder=folder, log=log,
+            "folders/{folder}/logs/{log}",
+            folder=folder,
+            log=log,
         )
 
     @classmethod
     def log_path(cls, project, log):
         """Return a fully-qualified log string."""
         return google.api_core.path_template.expand(
-            "projects/{project}/logs/{log}", project=project, log=log,
+            "projects/{project}/logs/{log}",
+            project=project,
+            log=log,
         )
 
     @classmethod
     def organization_path(cls, organization):
         """Return a fully-qualified organization string."""
         return google.api_core.path_template.expand(
-            "organizations/{organization}", organization=organization,
+            "organizations/{organization}",
+            organization=organization,
         )
 
     @classmethod
@@ -132,7 +143,8 @@ class LoggingServiceV2Client(object):
     def project_path(cls, project):
         """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
-            "projects/{project}", project=project,
+            "projects/{project}",
+            project=project,
         )
 
     def __init__(
@@ -221,8 +233,12 @@ class LoggingServiceV2Client(object):
                     )
                 self.transport = transport
         else:
-            self.transport = logging_service_v2_grpc_transport.LoggingServiceV2GrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials,
+            self.transport = (
+                logging_service_v2_grpc_transport.LoggingServiceV2GrpcTransport(
+                    address=api_endpoint,
+                    channel=channel,
+                    credentials=credentials,
+                )
             )
 
         if client_info is None:
@@ -311,7 +327,9 @@ class LoggingServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_pb2.DeleteLogRequest(log_name=log_name,)
+        request = logging_pb2.DeleteLogRequest(
+            log_name=log_name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -776,7 +794,10 @@ class LoggingServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_pb2.ListLogsRequest(parent=parent, page_size=page_size,)
+        request = logging_pb2.ListLogsRequest(
+            parent=parent,
+            page_size=page_size,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)

--- a/google/cloud/logging_v2/gapic/metrics_service_v2_client.py
+++ b/google/cloud/logging_v2/gapic/metrics_service_v2_client.py
@@ -46,7 +46,9 @@ from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2
 
 
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution("google-cloud-logging",).version
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    "google-cloud-logging",
+).version
 
 
 class MetricsServiceV2Client(object):
@@ -83,33 +85,41 @@ class MetricsServiceV2Client(object):
     def billing_path(cls, billing_account):
         """Return a fully-qualified billing string."""
         return google.api_core.path_template.expand(
-            "billingAccounts/{billing_account}", billing_account=billing_account,
+            "billingAccounts/{billing_account}",
+            billing_account=billing_account,
         )
 
     @classmethod
     def folder_path(cls, folder):
         """Return a fully-qualified folder string."""
-        return google.api_core.path_template.expand("folders/{folder}", folder=folder,)
+        return google.api_core.path_template.expand(
+            "folders/{folder}",
+            folder=folder,
+        )
 
     @classmethod
     def metric_path(cls, project, metric):
         """Return a fully-qualified metric string."""
         return google.api_core.path_template.expand(
-            "projects/{project}/metrics/{metric}", project=project, metric=metric,
+            "projects/{project}/metrics/{metric}",
+            project=project,
+            metric=metric,
         )
 
     @classmethod
     def organization_path(cls, organization):
         """Return a fully-qualified organization string."""
         return google.api_core.path_template.expand(
-            "organizations/{organization}", organization=organization,
+            "organizations/{organization}",
+            organization=organization,
         )
 
     @classmethod
     def project_path(cls, project):
         """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
-            "projects/{project}", project=project,
+            "projects/{project}",
+            project=project,
         )
 
     def __init__(
@@ -198,8 +208,12 @@ class MetricsServiceV2Client(object):
                     )
                 self.transport = transport
         else:
-            self.transport = metrics_service_v2_grpc_transport.MetricsServiceV2GrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials,
+            self.transport = (
+                metrics_service_v2_grpc_transport.MetricsServiceV2GrpcTransport(
+                    address=api_endpoint,
+                    channel=channel,
+                    credentials=credentials,
+                )
             )
 
         if client_info is None:
@@ -302,7 +316,8 @@ class MetricsServiceV2Client(object):
             )
 
         request = logging_metrics_pb2.ListLogMetricsRequest(
-            parent=parent, page_size=page_size,
+            parent=parent,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []
@@ -387,7 +402,9 @@ class MetricsServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_metrics_pb2.GetLogMetricRequest(metric_name=metric_name,)
+        request = logging_metrics_pb2.GetLogMetricRequest(
+            metric_name=metric_name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -473,7 +490,8 @@ class MetricsServiceV2Client(object):
             )
 
         request = logging_metrics_pb2.CreateLogMetricRequest(
-            parent=parent, metric=metric,
+            parent=parent,
+            metric=metric,
         )
         if metadata is None:
             metadata = []
@@ -560,7 +578,8 @@ class MetricsServiceV2Client(object):
             )
 
         request = logging_metrics_pb2.UpdateLogMetricRequest(
-            metric_name=metric_name, metric=metric,
+            metric_name=metric_name,
+            metric=metric,
         )
         if metadata is None:
             metadata = []
@@ -631,7 +650,9 @@ class MetricsServiceV2Client(object):
                 client_info=self._client_info,
             )
 
-        request = logging_metrics_pb2.DeleteLogMetricRequest(metric_name=metric_name,)
+        request = logging_metrics_pb2.DeleteLogMetricRequest(
+            metric_name=metric_name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)

--- a/google/cloud/logging_v2/proto/log_entry_pb2.py
+++ b/google/cloud/logging_v2/proto/log_entry_pb2.py
@@ -427,7 +427,9 @@ _LOGENTRY = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_LOGENTRY_LABELSENTRY,],
+    nested_types=[
+        _LOGENTRY_LABELSENTRY,
+    ],
     enum_types=[],
     serialized_options=_b(
         "\352A\271\001\n\032logging.googleapis.com/Log\022\035projects/{project}/logs/{log}\022'organizations/{organization}/logs/{log}\022\033folders/{folder}/logs/{log}\022,billingAccounts/{billing_account}/logs/{log}\032\010log_name"

--- a/google/cloud/logging_v2/proto/logging_config_pb2.py
+++ b/google/cloud/logging_v2/proto/logging_config_pb2.py
@@ -320,7 +320,9 @@ _LOGSINK = _descriptor.Descriptor(
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_LOGSINK_VERSIONFORMAT,],
+    enum_types=[
+        _LOGSINK_VERSIONFORMAT,
+    ],
     serialized_options=_b(
         "\352A\270\001\n\033logging.googleapis.com/Sink\022\037projects/{project}/sinks/{sink}\022)organizations/{organization}/sinks/{sink}\022\035folders/{folder}/sinks/{sink}\022.billingAccounts/{billing_account}/sinks/{sink}"
     ),

--- a/google/cloud/logging_v2/proto/logging_config_pb2_grpc.py
+++ b/google/cloud/logging_v2/proto/logging_config_pb2_grpc.py
@@ -8,15 +8,14 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class ConfigServiceV2Stub(object):
-    """Service for configuring sinks used to route log entries.
-  """
+    """Service for configuring sinks used to route log entries."""
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.ListSinks = channel.unary_unary(
             "/google.logging.v2.ConfigServiceV2/ListSinks",
             request_serializer=google_dot_cloud_dot_logging__v2_dot_proto_dot_logging__config__pb2.ListSinksRequest.SerializeToString,
@@ -80,85 +79,78 @@ class ConfigServiceV2Stub(object):
 
 
 class ConfigServiceV2Servicer(object):
-    """Service for configuring sinks used to route log entries.
-  """
+    """Service for configuring sinks used to route log entries."""
 
     def ListSinks(self, request, context):
-        """Lists sinks.
-    """
+        """Lists sinks."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetSink(self, request, context):
-        """Gets a sink.
-    """
+        """Gets a sink."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateSink(self, request, context):
         """Creates a sink that exports specified log entries to a destination. The
-    export of newly-ingested log entries begins immediately, unless the sink's
-    `writer_identity` is not permitted to write to the destination. A sink can
-    export log entries only from the resource owning the sink.
-    """
+        export of newly-ingested log entries begins immediately, unless the sink's
+        `writer_identity` is not permitted to write to the destination. A sink can
+        export log entries only from the resource owning the sink.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateSink(self, request, context):
         """Updates a sink. This method replaces the following fields in the existing
-    sink with values from the new sink: `destination`, and `filter`.
+        sink with values from the new sink: `destination`, and `filter`.
 
-    The updated sink might also have a new `writer_identity`; see the
-    `unique_writer_identity` field.
-    """
+        The updated sink might also have a new `writer_identity`; see the
+        `unique_writer_identity` field.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteSink(self, request, context):
         """Deletes a sink. If the sink has a unique `writer_identity`, then that
-    service account is also deleted.
-    """
+        service account is also deleted.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListExclusions(self, request, context):
-        """Lists all the exclusions in a parent resource.
-    """
+        """Lists all the exclusions in a parent resource."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetExclusion(self, request, context):
-        """Gets the description of an exclusion.
-    """
+        """Gets the description of an exclusion."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateExclusion(self, request, context):
         """Creates a new exclusion in a specified parent resource.
-    Only log entries belonging to that resource can be excluded.
-    You can have up to 10 exclusions in a resource.
-    """
+        Only log entries belonging to that resource can be excluded.
+        You can have up to 10 exclusions in a resource.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateExclusion(self, request, context):
-        """Changes one or more properties of an existing exclusion.
-    """
+        """Changes one or more properties of an existing exclusion."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteExclusion(self, request, context):
-        """Deletes an exclusion.
-    """
+        """Deletes an exclusion."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -166,13 +158,13 @@ class ConfigServiceV2Servicer(object):
     def GetCmekSettings(self, request, context):
         """Gets the Logs Router CMEK settings for the given resource.
 
-    Note: CMEK for the Logs Router can currently only be configured for GCP
-    organizations. Once configured, it applies to all projects and folders in
-    the GCP organization.
+        Note: CMEK for the Logs Router can currently only be configured for GCP
+        organizations. Once configured, it applies to all projects and folders in
+        the GCP organization.
 
-    See [Enabling CMEK for Logs
-    Router](/logging/docs/routing/managed-encryption) for more information.
-    """
+        See [Enabling CMEK for Logs
+        Router](/logging/docs/routing/managed-encryption) for more information.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -180,19 +172,19 @@ class ConfigServiceV2Servicer(object):
     def UpdateCmekSettings(self, request, context):
         """Updates the Logs Router CMEK settings for the given resource.
 
-    Note: CMEK for the Logs Router can currently only be configured for GCP
-    organizations. Once configured, it applies to all projects and folders in
-    the GCP organization.
+        Note: CMEK for the Logs Router can currently only be configured for GCP
+        organizations. Once configured, it applies to all projects and folders in
+        the GCP organization.
 
-    [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings]
-    will fail if 1) `kms_key_name` is invalid, or 2) the associated service
-    account does not have the required
-    `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
-    3) access to the key is disabled.
+        [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings]
+        will fail if 1) `kms_key_name` is invalid, or 2) the associated service
+        account does not have the required
+        `roles/cloudkms.cryptoKeyEncrypterDecrypter` role assigned for the key, or
+        3) access to the key is disabled.
 
-    See [Enabling CMEK for Logs
-    Router](/logging/docs/routing/managed-encryption) for more information.
-    """
+        See [Enabling CMEK for Logs
+        Router](/logging/docs/routing/managed-encryption) for more information.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/logging_v2/proto/logging_metrics_pb2.py
+++ b/google/cloud/logging_v2/proto/logging_metrics_pb2.py
@@ -318,8 +318,12 @@ _LOGMETRIC = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_LOGMETRIC_LABELEXTRACTORSENTRY,],
-    enum_types=[_LOGMETRIC_APIVERSION,],
+    nested_types=[
+        _LOGMETRIC_LABELEXTRACTORSENTRY,
+    ],
+    enum_types=[
+        _LOGMETRIC_APIVERSION,
+    ],
     serialized_options=_b(
         "\352AD\n\035logging.googleapis.com/Metric\022#projects/{project}/metrics/{metric}"
     ),

--- a/google/cloud/logging_v2/proto/logging_metrics_pb2_grpc.py
+++ b/google/cloud/logging_v2/proto/logging_metrics_pb2_grpc.py
@@ -8,15 +8,14 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class MetricsServiceV2Stub(object):
-    """Service for configuring logs-based metrics.
-  """
+    """Service for configuring logs-based metrics."""
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.ListLogMetrics = channel.unary_unary(
             "/google.logging.v2.MetricsServiceV2/ListLogMetrics",
             request_serializer=google_dot_cloud_dot_logging__v2_dot_proto_dot_logging__metrics__pb2.ListLogMetricsRequest.SerializeToString,
@@ -45,40 +44,34 @@ class MetricsServiceV2Stub(object):
 
 
 class MetricsServiceV2Servicer(object):
-    """Service for configuring logs-based metrics.
-  """
+    """Service for configuring logs-based metrics."""
 
     def ListLogMetrics(self, request, context):
-        """Lists logs-based metrics.
-    """
+        """Lists logs-based metrics."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetLogMetric(self, request, context):
-        """Gets a logs-based metric.
-    """
+        """Gets a logs-based metric."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateLogMetric(self, request, context):
-        """Creates a logs-based metric.
-    """
+        """Creates a logs-based metric."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateLogMetric(self, request, context):
-        """Creates or updates a logs-based metric.
-    """
+        """Creates or updates a logs-based metric."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteLogMetric(self, request, context):
-        """Deletes a logs-based metric.
-    """
+        """Deletes a logs-based metric."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/logging_v2/proto/logging_pb2.py
+++ b/google/cloud/logging_v2/proto/logging_pb2.py
@@ -274,7 +274,9 @@ _WRITELOGENTRIESREQUEST = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_WRITELOGENTRIESREQUEST_LABELSENTRY,],
+    nested_types=[
+        _WRITELOGENTRIESREQUEST_LABELSENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -389,7 +391,9 @@ _WRITELOGENTRIESPARTIALERRORS = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_WRITELOGENTRIESPARTIALERRORS_LOGENTRYERRORSENTRY,],
+    nested_types=[
+        _WRITELOGENTRIESPARTIALERRORS_LOGENTRYERRORSENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/google/cloud/logging_v2/proto/logging_pb2_grpc.py
+++ b/google/cloud/logging_v2/proto/logging_pb2_grpc.py
@@ -8,15 +8,14 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class LoggingServiceV2Stub(object):
-    """Service for ingesting and querying logs.
-  """
+    """Service for ingesting and querying logs."""
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.DeleteLog = channel.unary_unary(
             "/google.logging.v2.LoggingServiceV2/DeleteLog",
             request_serializer=google_dot_cloud_dot_logging__v2_dot_proto_dot_logging__pb2.DeleteLogRequest.SerializeToString,
@@ -45,52 +44,50 @@ class LoggingServiceV2Stub(object):
 
 
 class LoggingServiceV2Servicer(object):
-    """Service for ingesting and querying logs.
-  """
+    """Service for ingesting and querying logs."""
 
     def DeleteLog(self, request, context):
         """Deletes all the log entries in a log. The log reappears if it receives new
-    entries. Log entries written shortly before the delete operation might not
-    be deleted. Entries received after the delete operation with a timestamp
-    before the operation will be deleted.
-    """
+        entries. Log entries written shortly before the delete operation might not
+        be deleted. Entries received after the delete operation with a timestamp
+        before the operation will be deleted.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def WriteLogEntries(self, request, context):
         """Writes log entries to Logging. This API method is the
-    only way to send log entries to Logging. This method
-    is used, directly or indirectly, by the Logging agent
-    (fluentd) and all logging libraries configured to use Logging.
-    A single request may contain log entries for a maximum of 1000
-    different resources (projects, organizations, billing accounts or
-    folders)
-    """
+        only way to send log entries to Logging. This method
+        is used, directly or indirectly, by the Logging agent
+        (fluentd) and all logging libraries configured to use Logging.
+        A single request may contain log entries for a maximum of 1000
+        different resources (projects, organizations, billing accounts or
+        folders)
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListLogEntries(self, request, context):
         """Lists log entries.  Use this method to retrieve log entries that originated
-    from a project/folder/organization/billing account.  For ways to export log
-    entries, see [Exporting Logs](/logging/docs/export).
-    """
+        from a project/folder/organization/billing account.  For ways to export log
+        entries, see [Exporting Logs](/logging/docs/export).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListMonitoredResourceDescriptors(self, request, context):
-        """Lists the descriptors for monitored resource types used by Logging.
-    """
+        """Lists the descriptors for monitored resource types used by Logging."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListLogs(self, request, context):
         """Lists the logs in projects, organizations, folders, or billing accounts.
-    Only logs that have entries are listed.
-    """
+        Only logs that have entries are listed.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.15.1"
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "google-cloud-core >= 1.1.0, < 2.0dev",
+    "google-cloud-core >= 1.1.0, < 3.0dev",
 ]
 extras = {
 }

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "1.15.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = 'Development Status :: 5 - Production/Stable'
 dependencies = [
-    "google-api-core[grpc] >= 1.15.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 1.1.0, < 2.0dev",
 ]
 extras = {

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -450,7 +450,7 @@ class Test__parse_log_entry(unittest.TestCase):
     def test_simple(self):
         from google.cloud.logging_v2.proto.log_entry_pb2 import LogEntry
 
-        entry_pb = LogEntry(log_name=u"lol-jk", text_payload=u"bah humbug")
+        entry_pb = LogEntry(log_name="lol-jk", text_payload="bah humbug")
         result = self._call_fut(entry_pb)
         expected = {"logName": entry_pb.log_name, "textPayload": entry_pb.text_payload}
         self.assertEqual(result, expected)
@@ -506,11 +506,11 @@ class Test__parse_log_entry(unittest.TestCase):
 
         type_url = "type.googleapis.com/" + type_name
         field_name = "foo"
-        field_value = u"Bar"
+        field_value = "Bar"
         struct_pb = Struct(fields={field_name: Value(string_value=field_value)})
         any_pb = any_pb2.Any(type_url=type_url, value=struct_pb.SerializeToString())
 
-        entry_pb = LogEntry(proto_payload=any_pb, log_name=u"all-good")
+        entry_pb = LogEntry(proto_payload=any_pb, log_name="all-good")
         result = self._call_fut(entry_pb)
         expected_proto = {
             "logName": entry_pb.log_name,
@@ -566,9 +566,9 @@ class Test__log_entry_mapping_to_pb(unittest.TestCase):
 
         type_url = "type.googleapis.com/" + type_name
         field_name = "foo"
-        field_value = u"Bar"
+        field_value = "Bar"
         json_mapping = {
-            "logName": u"hi-everybody",
+            "logName": "hi-everybody",
             "protoPayload": {"@type": type_url, "value": {field_name: field_value}},
         }
         # Convert to a valid LogEntry.

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -49,10 +49,19 @@ class TestConnection(unittest.TestCase):
         self.assertIs(conn._client, client)
 
     def test_build_api_url_w_custom_endpoint(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         custom_endpoint = "https://foo-logging.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join([custom_endpoint, conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_extra_headers(self):
         import requests

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -181,7 +181,7 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
 
     def test_log_text_w_unicode_and_default_labels(self):
-        TEXT = u"TEXT"
+        TEXT = "TEXT"
         DEFAULT_LABELS = {"foo": "spam"}
         ENTRIES = [
             {


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566