### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v2 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-appengine-logging>=0.1.0, <2.0.0dev",
     "google-cloud-audit-log >= 0.1.0, < 1.0.0dev",
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,6 +5,6 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.28.0
+google-api-core==1.31.5
 google-cloud-core==1.4.1
 proto-plus==1.15.0


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v2**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566