### PR TITLE
docs: Update README image to absolute URL, fix PyPI rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ For an interactive walkthrough on how to use this library in a python applicatio
 
 |guide|
 
-.. |guide| image:: _static/guide-me.png
+.. |guide| image:: https://raw.githubusercontent.com/googleapis/python-logging/main/_static/guide-me.png
    :target: https://console.cloud.google.com/?walkthrough_id=logging__logging-python
 
 Installation


### PR DESCRIPTION
When viewing the [v3.1.1](https://pypi.org/project/google-cloud-logging/3.1.1/) README on PyPI, the new "Guide Me" button is a broken image link. 

<img width="586" alt="broken image" src="https://user-images.githubusercontent.com/813732/170630757-c0b83023-2587-4940-b5aa-ab18292ceefa.png">


This is a known issue where PyPI needs absolute image links (ref https://github.com/pypa/warehouse/issues/5582#issuecomment-570222929). 

By using the GitHub README's absolute URL of the image (from the `raw.githubusercontent.com` domain), the absolute URL can be referenced and rendered on both PyPI and GitHub README's. 

Since confirming this fix requires publishing to PyPI, I've published an example package to show the before/after: 

* Before: https://pypi.org/project/glasnt-pypi-image-example/0.0.1/ ([code](https://github.com/glasnt/pypi-image-example/commit/fb5d141771954f15cba241145a6f3b32701ba6b0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7))
* After: https://pypi.org/project/glasnt-pypi-image-example/0.0.2/ ([code](https://github.com/glasnt/pypi-image-example/commit/8cc78a825c33dfefaee51d15d28555b7bb06b9f0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7))
