### PR TITLE
fix: structured log handler drops reserved fields in json_fields

### DIFF
--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -36,6 +36,13 @@ GCP_FORMAT = (
     "}"
 )
 
+GCP_STRUCTURED_LOGGING_FIELDS = frozenset({
+    "severity", "httpRequest", "time", "timestamp",
+    "timestampSeconds", "timestampNanos", "logging.googleapis.com/insertId",
+    "logging.googleapis.com/labels", "logging.googleapis.com/operation",
+    "logging.googleapis.com/sourceLocation", "logging.googleapis.com/spanId",
+    "logging.googleapis.com/trace", "logging.googleapis.com/trace_sampled"
+    })
 
 class StructuredLogHandler(logging.StreamHandler):
     """Handler to format logs into the Cloud Logging structured log format,
@@ -70,6 +77,10 @@ class StructuredLogHandler(logging.StreamHandler):
         message = _format_and_parse_message(record, super(StructuredLogHandler, self))
 
         if isinstance(message, collections.abc.Mapping):
+            # remove any special fields
+            for key in list(message.keys()):
+                if key in GCP_STRUCTURED_LOGGING_FIELDS:
+                    del message[key]
             # if input is a dictionary, encode it as a json string
             encoded_msg = json.dumps(message, ensure_ascii=False)
             # strip out open and close parentheses

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -36,6 +36,8 @@ GCP_FORMAT = (
     "}"
 )
 
+# reserved fields taken from Structured Logging documentation:
+# https://cloud.google.com/logging/docs/structured-logging
 GCP_STRUCTURED_LOGGING_FIELDS = frozenset(
     {
         "severity",

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -36,13 +36,24 @@ GCP_FORMAT = (
     "}"
 )
 
-GCP_STRUCTURED_LOGGING_FIELDS = frozenset({
-    "severity", "httpRequest", "time", "timestamp",
-    "timestampSeconds", "timestampNanos", "logging.googleapis.com/insertId",
-    "logging.googleapis.com/labels", "logging.googleapis.com/operation",
-    "logging.googleapis.com/sourceLocation", "logging.googleapis.com/spanId",
-    "logging.googleapis.com/trace", "logging.googleapis.com/trace_sampled"
-    })
+GCP_STRUCTURED_LOGGING_FIELDS = frozenset(
+    {
+        "severity",
+        "httpRequest",
+        "time",
+        "timestamp",
+        "timestampSeconds",
+        "timestampNanos",
+        "logging.googleapis.com/insertId",
+        "logging.googleapis.com/labels",
+        "logging.googleapis.com/operation",
+        "logging.googleapis.com/sourceLocation",
+        "logging.googleapis.com/spanId",
+        "logging.googleapis.com/trace",
+        "logging.googleapis.com/trace_sampled",
+    }
+)
+
 
 class StructuredLogHandler(logging.StreamHandler):
     """Handler to format logs into the Cloud Logging structured log format,

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -222,6 +222,7 @@ class TestStructuredLogHandler(unittest.TestCase):
             "logging.googleapis.com/trace_sampled": True,
             "time": "none",
             "extra": extra,
+            "SEVERITY": "error",
         }
         record = logging.LogRecord(
             None,
@@ -237,6 +238,7 @@ class TestStructuredLogHandler(unittest.TestCase):
         expected_payload = {
             "message": message,
             "severity": "INFO",
+            "SEVERITY": "error",
             "logging.googleapis.com/trace": "",
             "logging.googleapis.com/spanId": "",
             "logging.googleapis.com/trace_sampled": False,

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -207,6 +207,52 @@ class TestStructuredLogHandler(unittest.TestCase):
         self.assertIn(expected_result, result)
         self.assertIn("message", result)
 
+    def test_format_with_reserved_json_field(self):
+        # drop json_field data with reserved names
+        # related issue: https://github.com/googleapis/python-logging/issues/543
+        import logging
+        import json
+
+        handler = self._make_one()
+        message = "hello world"
+        extra = "still here"
+        json_fields = {
+            "message": "override?",
+            "severity": "error",
+            "logging.googleapis.com/trace_sampled": True,
+            "time": "none",
+            "extra": extra,
+        }
+        record = logging.LogRecord(
+            None,
+            logging.INFO,
+            None,
+            None,
+            message,
+            None,
+            None,
+        )
+        record.created = None
+        setattr(record, "json_fields", json_fields)
+        expected_payload = {
+            "message": message,
+            "severity": "INFO",
+            "logging.googleapis.com/trace": "",
+            "logging.googleapis.com/spanId": "",
+            "logging.googleapis.com/trace_sampled": False,
+            "logging.googleapis.com/sourceLocation": {},
+            "httpRequest": {},
+            "logging.googleapis.com/labels": {},
+            "extra": extra,
+        }
+        handler.filter(record)
+        result = json.loads(handler.format(record))
+        self.assertEqual(set(expected_payload.keys()), set(result.keys()))
+        for (key, value) in expected_payload.items():
+            self.assertEqual(
+                value, result[key], f"expected_payload[{key}] != result[{key}]"
+            )
+
     def test_dict(self):
         """
         Handler should parse json encoded as a string


### PR DESCRIPTION
Fixes: https://github.com/googleapis/python-logging/issues/543

Adding reserved fields like `severity` to the `json_fields` for the StructuredLogHandler was causing issues, as the json fields would attempt to overwrite the fields in the LogEntry, rather than staying in the jsonPayload, as intended. 

This PR fixes this by maintaining a list of reserved field names (taken from the [structured logging spec](https://cloud.google.com/logging/docs/structured-logging)), and filtering them out of `json_fields` before printing the log
