### PR TITLE
feat: set partial_success to default to true for batched logs

### DIFF
--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -121,7 +121,7 @@ class _LoggingAPI(object):
         logger_name=None,
         resource=None,
         labels=None,
-        partial_success=False,
+        partial_success=True,
         dry_run=False,
     ):
         """Log an entry resource via a POST request

--- a/google/cloud/logging_v2/_http.py
+++ b/google/cloud/logging_v2/_http.py
@@ -144,7 +144,7 @@ class _LoggingAPI(object):
         logger_name=None,
         resource=None,
         labels=None,
-        partial_success=False,
+        partial_success=True,
         dry_run=False,
     ):
         """Log an entry resource via a POST request

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -135,7 +135,6 @@ class Logger(object):
         kw["log_name"] = kw.pop("log_name", self.full_name)
         kw["labels"] = kw.pop("labels", self.labels)
         kw["resource"] = kw.pop("resource", self.default_resource)
-        partial_success = False
 
         severity = kw.get("severity", None)
         if isinstance(severity, str) and not severity.isupper():
@@ -159,11 +158,10 @@ class Logger(object):
         api_repr = entry.to_api_repr()
         entries = [api_repr]
         if google.cloud.logging_v2._instrumentation_emitted is False:
-            partial_success = True
             entries = _add_instrumentation(entries, **kw)
             google.cloud.logging_v2._instrumentation_emitted = True
-
-        client.logging_api.write_entries(entries, partial_success=partial_success)
+        # partial_success is true to avoid dropping instrumentation logs
+        client.logging_api.write_entries(entries, partial_success=True)
 
     def log_empty(self, *, client=None, **kw):
         """Log an empty message
@@ -437,13 +435,17 @@ class Batch(object):
             entry_type = TextEntry
         self.entries.append(entry_type(payload=message, **kw))
 
-    def commit(self, *, client=None):
+    def commit(self, *, client=None, partial_success=True):
         """Send saved log entries as a single API call.
 
         Args:
             client (Optional[~logging_v2.client.Client]):
                 The client to use.  If not passed, falls back to the
                 ``client`` stored on the current batch.
+            partial_success (Optional[bool]):
+                Whether a batch's valid entries should be written even
+                if some other entry failed due to a permanent error such
+                as INVALID_ARGUMENT or PERMISSION_DENIED.
         """
         if client is None:
             client = self.client
@@ -458,5 +460,5 @@ class Batch(object):
 
         entries = [entry.to_api_repr() for entry in self.entries]
 
-        client.logging_api.write_entries(entries, **kwargs)
+        client.logging_api.write_entries(entries, partial_success=partial_success, **kwargs)
         del self.entries[:]

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -460,5 +460,7 @@ class Batch(object):
 
         entries = [entry.to_api_repr() for entry in self.entries]
 
-        client.logging_api.write_entries(entries, partial_success=partial_success, **kwargs)
+        client.logging_api.write_entries(
+            entries, partial_success=partial_success, **kwargs
+        )
         del self.entries[:]

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -167,7 +167,7 @@ class Test_LoggingAPI(unittest.TestCase):
         # Check the request
         call.assert_called_once()
         request = call.call_args.args[0]
-        assert request.partial_success is False
+        assert request.partial_success is True
         assert len(request.entries) == 1
         assert request.entries[0].log_name == entry["logName"]
         assert request.entries[0].resource.type == entry["resource"]["type"]

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -306,7 +306,7 @@ class Test_LoggingAPI(unittest.TestCase):
         client = _Client(conn)
         api = self._make_one(client)
 
-        api.write_entries([ENTRY])
+        api.write_entries([ENTRY], partial_success=False)
 
         self.assertEqual(conn._called_with["method"], "POST")
         path = f"/{self.WRITE_ENTRIES_PATH}"
@@ -325,7 +325,7 @@ class Test_LoggingAPI(unittest.TestCase):
             "resource": RESOURCE,
             "labels": LABELS,
             "entries": [ENTRY1, ENTRY2],
-            "partialSuccess": False,
+            "partialSuccess": True,
             "dry_run": False,
         }
         conn = _Connection({})

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -123,7 +123,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_empty()
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_empty_w_explicit(self):
         import datetime
@@ -177,7 +177,7 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_text_defaults(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -199,7 +199,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_text_w_unicode_and_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -223,7 +223,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_text_explicit(self):
         import datetime
@@ -280,7 +280,7 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_struct_defaults(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -302,7 +302,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_nested_struct(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -324,7 +324,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_struct_w_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -348,7 +348,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_struct_w_explicit(self):
         import datetime
@@ -405,7 +405,7 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_struct_inference(self):
         """
@@ -439,7 +439,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT, resource=RESOURCE)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_w_dict_resource(self):
         """
@@ -467,7 +467,7 @@ class TestLogger(unittest.TestCase):
             }
         ]
         logger.log(MESSAGE, resource=resource)
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_lowercase_severity(self):
         """
@@ -505,7 +505,7 @@ class TestLogger(unittest.TestCase):
             logger.log(MESSAGE, severity=lower_severity)
 
             self.assertEqual(
-                api._write_entries_called_with, (ENTRIES, None, None, None)
+                api._write_entries_called_with, (ENTRIES, None, None, None, True)
             )
 
     def test_log_proto_defaults(self):
@@ -530,7 +530,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_proto_w_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -556,7 +556,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_proto_w_explicit(self):
         import json
@@ -617,7 +617,7 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_inference_empty(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -638,7 +638,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log()
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_inference_text(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -659,7 +659,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_inference_struct(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -680,7 +680,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_log_inference_proto(self):
         import json
@@ -704,7 +704,7 @@ class TestLogger(unittest.TestCase):
 
         logger.log(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
@@ -1033,12 +1033,12 @@ class TestLogger(unittest.TestCase):
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client, labels=DEFAULT_LABELS)
         logger.log_empty()
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
         ENTRIES = ENTRIES[-1:]
         api = client.logging_api = _DummyLoggingAPI()
         logger.log_empty()
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None))
+        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
 
 
 class TestBatch(unittest.TestCase):
@@ -1436,7 +1436,7 @@ class TestBatch(unittest.TestCase):
 
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
-            api._write_entries_called_with, ([ENTRY], logger.full_name, None, None)
+            api._write_entries_called_with, ([ENTRY], logger.full_name, None, None, True)
         )
 
     def test_commit_w_resource_specified(self):
@@ -1461,7 +1461,7 @@ class TestBatch(unittest.TestCase):
         batch.commit()
         self.assertEqual(
             api._write_entries_called_with,
-            (ENTRIES, logger.full_name, RESOURCE._to_dict(), None),
+            (ENTRIES, logger.full_name, RESOURCE._to_dict(), None, True),
         )
 
     def test_commit_w_bound_client(self):
@@ -1550,7 +1550,7 @@ class TestBatch(unittest.TestCase):
 
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
-            api._write_entries_called_with, (ENTRIES, logger.full_name, None, None)
+            api._write_entries_called_with, (ENTRIES, logger.full_name, None, None, True)
         )
 
     def test_commit_w_alternate_client(self):
@@ -1597,12 +1597,12 @@ class TestBatch(unittest.TestCase):
         batch.log_text(TEXT, labels=LABELS)
         batch.log_struct(STRUCT, severity=SEVERITY)
         batch.log_proto(message, http_request=REQUEST)
-        batch.commit(client=client2)
+        batch.commit(client=client2, partial_success=False)
 
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
             api._write_entries_called_with,
-            (ENTRIES, logger.full_name, None, DEFAULT_LABELS),
+            (ENTRIES, logger.full_name, None, DEFAULT_LABELS, False),
         )
 
     def test_context_mgr_success(self):
@@ -1653,7 +1653,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
             api._write_entries_called_with,
-            (ENTRIES, logger.full_name, None, DEFAULT_LABELS),
+            (ENTRIES, logger.full_name, None, DEFAULT_LABELS, True),
         )
 
     def test_context_mgr_failure(self):
@@ -1719,7 +1719,7 @@ class _DummyLoggingAPI(object):
         labels=None,
         partial_success=False,
     ):
-        self._write_entries_called_with = (entries, logger_name, resource, labels)
+        self._write_entries_called_with = (entries, logger_name, resource, labels, partial_success)
 
     def logger_delete(self, logger_name):
         self._logger_delete_called_with = logger_name

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -123,7 +123,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_empty()
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_empty_w_explicit(self):
         import datetime
@@ -177,7 +179,9 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_text_defaults(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -199,7 +203,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_text_w_unicode_and_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -223,7 +229,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_text(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_text_explicit(self):
         import datetime
@@ -280,7 +288,9 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_struct_defaults(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -302,7 +312,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_nested_struct(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -324,7 +336,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_struct_w_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -348,7 +362,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_struct_w_explicit(self):
         import datetime
@@ -405,7 +421,9 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_struct_inference(self):
         """
@@ -439,7 +457,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_struct(STRUCT, resource=RESOURCE)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_w_dict_resource(self):
         """
@@ -467,7 +487,9 @@ class TestLogger(unittest.TestCase):
             }
         ]
         logger.log(MESSAGE, resource=resource)
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_lowercase_severity(self):
         """
@@ -530,7 +552,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_proto_w_default_labels(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -556,7 +580,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log_proto(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_proto_w_explicit(self):
         import json
@@ -617,7 +643,9 @@ class TestLogger(unittest.TestCase):
             trace_sampled=True,
         )
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_inference_empty(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -638,7 +666,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log()
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_inference_text(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -659,7 +689,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log(TEXT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_inference_struct(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
@@ -680,7 +712,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log(STRUCT)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_log_inference_proto(self):
         import json
@@ -704,7 +738,9 @@ class TestLogger(unittest.TestCase):
 
         logger.log(message)
 
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
     def test_delete_w_bound_client(self):
         client = _Client(project=self.PROJECT)
@@ -1033,12 +1069,16 @@ class TestLogger(unittest.TestCase):
         api = client.logging_api = _DummyLoggingAPI()
         logger = self._make_one(self.LOGGER_NAME, client=client, labels=DEFAULT_LABELS)
         logger.log_empty()
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
         ENTRIES = ENTRIES[-1:]
         api = client.logging_api = _DummyLoggingAPI()
         logger.log_empty()
-        self.assertEqual(api._write_entries_called_with, (ENTRIES, None, None, None, True))
+        self.assertEqual(
+            api._write_entries_called_with, (ENTRIES, None, None, None, True)
+        )
 
 
 class TestBatch(unittest.TestCase):
@@ -1436,7 +1476,8 @@ class TestBatch(unittest.TestCase):
 
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
-            api._write_entries_called_with, ([ENTRY], logger.full_name, None, None, True)
+            api._write_entries_called_with,
+            ([ENTRY], logger.full_name, None, None, True),
         )
 
     def test_commit_w_resource_specified(self):
@@ -1550,7 +1591,8 @@ class TestBatch(unittest.TestCase):
 
         self.assertEqual(list(batch.entries), [])
         self.assertEqual(
-            api._write_entries_called_with, (ENTRIES, logger.full_name, None, None, True)
+            api._write_entries_called_with,
+            (ENTRIES, logger.full_name, None, None, True),
         )
 
     def test_commit_w_alternate_client(self):
@@ -1719,7 +1761,13 @@ class _DummyLoggingAPI(object):
         labels=None,
         partial_success=False,
     ):
-        self._write_entries_called_with = (entries, logger_name, resource, labels, partial_success)
+        self._write_entries_called_with = (
+            entries,
+            logger_name,
+            resource,
+            labels,
+            partial_success,
+        )
 
     def logger_delete(self, logger_name):
         self._logger_delete_called_with = logger_name


### PR DESCRIPTION
By default, if one log in a batch fails (ex: due to large size), the entire batch will be dropped. This PR sets the `partial_success` flag by default, so other logs will still be processed. We also expose `partial_success` as an optional argument to `batch.commit()`, so users can override the behavior if needed.

Note that most `logger.log` functions only typically write a single log entries, so this functionality is only strictly needed for batching. The only exception is when writing instrumentation logs, where a `logger.log` call may write two entries. For this reason, `partial_success` is always set to true for these calls

Fixes https://github.com/googleapis/python-logging/issues/448
