### PR TITLE
feat: include context on batch log errors

### DIFF
--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -486,7 +486,7 @@ class Batch(object):
             # find debug info proto if in details
             debug_info = next(x for x in err.details if isinstance(x, DebugInfo))
             # parse out the index of the faulty entry
-            error_idx = re.search('(?<=key: )[0-9]+', debug_info.detail).group(0)
+            error_idx = re.search("(?<=key: )[0-9]+", debug_info.detail).group(0)
             # find the faulty entry object
             found_entry = self.entries[int(error_idx)]
             str_entry = str(found_entry.to_api_repr())

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -490,7 +490,7 @@ class Batch(object):
             # find the faulty entry object
             found_entry = self.entries[int(error_idx)]
             # modify error message to contain extra context
-            err.message = f"{err.message}: {str(found_entry):.2000}"
+            err.message = f"{err.message}: {str(found_entry):.2000}..."
         except:
-            # abort changes and leave err unmodified
+            # if parsing fails, abort changes and leave err unmodified
             pass

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -489,8 +489,9 @@ class Batch(object):
             error_idx = re.search('(?<=key: )[0-9]+', debug_info.detail).group(0)
             # find the faulty entry object
             found_entry = self.entries[int(error_idx)]
+            str_entry = str(found_entry.to_api_repr())
             # modify error message to contain extra context
-            err.message = f"{err.message}: {str(found_entry):.2000}..."
-        except:
+            err.message = f"{err.message}: {str_entry:.2000}..."
+        except Exception:
             # if parsing fails, abort changes and leave err unmodified
             pass

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -16,8 +16,10 @@ from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+import sys
 
 import unittest
+import pytest
 
 import mock
 
@@ -1739,6 +1741,10 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch.entries), UNSENT)
         self.assertIsNone(api._write_entries_called_with)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="InvalidArgument init with details requires python3.8+",
+    )
     def test_append_context_to_error(self):
         """
         If an InvalidArgument exception contains info on the log that threw it,
@@ -1787,6 +1793,10 @@ class TestBatch(unittest.TestCase):
             err.message, starting_message, "message should have been unchanged"
         )
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="InvalidArgument init with details requires python3.8+",
+    )
     def test_batch_error_gets_context(self):
         """
         Simulate an InvalidArgument sent as part of a batch commit, to ensure

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1706,6 +1706,7 @@ class TestBatch(unittest.TestCase):
         from google.api_core.exceptions import InvalidArgument
         from google.rpc.error_details_pb2 import DebugInfo
         from google.cloud.logging import TextEntry
+
         logger = _Logger()
         client = _Client(project=self.PROJECT)
         batch = self._make_one(logger, client=client)
@@ -1715,25 +1716,34 @@ class TestBatch(unittest.TestCase):
         # test that properly formatted exceptions add log details
         for idx, entry in enumerate(test_entries):
             api_entry = entry.to_api_repr()
-            err = InvalidArgument(starting_message,
-                details=["padding", DebugInfo(detail=f"key: {idx}")])
+            err = InvalidArgument(
+                starting_message, details=["padding", DebugInfo(detail=f"key: {idx}")]
+            )
             batch._append_context_to_error(err)
             self.assertEqual(err.message, f"{starting_message}: {str(api_entry)}...")
             self.assertIn(str(idx), str(entry))
         # test with missing debug info
         err = InvalidArgument(starting_message, details=[])
         batch._append_context_to_error(err)
-        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+        self.assertEqual(
+            err.message, starting_message, "message should have been unchanged"
+        )
         # test with missing key
-        err = InvalidArgument(starting_message,
-                details=["padding", DebugInfo(detail=f"no k e y here")])
+        err = InvalidArgument(
+            starting_message, details=["padding", DebugInfo(detail=f"no k e y here")]
+        )
         batch._append_context_to_error(err)
-        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+        self.assertEqual(
+            err.message, starting_message, "message should have been unchanged"
+        )
         # test with key out of range
-        err = InvalidArgument(starting_message,
-                              details=["padding", DebugInfo(detail=f"key: 100")])
+        err = InvalidArgument(
+            starting_message, details=["padding", DebugInfo(detail=f"key: 100")]
+        )
         batch._append_context_to_error(err)
-        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+        self.assertEqual(
+            err.message, starting_message, "message should have been unchanged"
+        )
 
     def test_batch_error_gets_context(self):
         """
@@ -1743,10 +1753,13 @@ class TestBatch(unittest.TestCase):
         from google.api_core.exceptions import InvalidArgument
         from google.rpc.error_details_pb2 import DebugInfo
         from google.cloud.logging import TextEntry
+
         logger = _Logger()
         client = _Client(project=self.PROJECT)
         starting_message = "hello"
-        exception = InvalidArgument(starting_message, details=[DebugInfo(detail=f"key: 1")])
+        exception = InvalidArgument(
+            starting_message, details=[DebugInfo(detail=f"key: 1")]
+        )
         client.logging_api = _DummyLoggingExceptionAPI(exception)
         batch = self._make_one(logger, client=client)
         test_entries = [TextEntry(payload=str(i)) for i in range(11)]
@@ -1756,6 +1769,7 @@ class TestBatch(unittest.TestCase):
             expected_log = test_entries[1]
             api_entry = expected_log.to_api_repr()
             self.assertEqual(e.message, f"{starting_message}: {str(api_entry)}...")
+
 
 class _Logger(object):
 
@@ -1785,7 +1799,6 @@ class _DummyLoggingAPI(object):
 
 
 class _DummyLoggingExceptionAPI(object):
-
     def __init__(self, exception):
         self.exception = exception
 
@@ -1802,6 +1815,7 @@ class _DummyLoggingExceptionAPI(object):
 
     def logger_delete(self, logger_name):
         raise self.exception
+
 
 class _Client(object):
     def __init__(self, project, connection=None):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1778,7 +1778,7 @@ class TestBatch(unittest.TestCase):
         )
         # test with missing key
         err = InvalidArgument(
-            starting_message, details=["padding", DebugInfo(detail=f"no k e y here")]
+            starting_message, details=["padding", DebugInfo(detail="no k e y here")]
         )
         batch._append_context_to_error(err)
         self.assertEqual(
@@ -1786,7 +1786,7 @@ class TestBatch(unittest.TestCase):
         )
         # test with key out of range
         err = InvalidArgument(
-            starting_message, details=["padding", DebugInfo(detail=f"key: 100")]
+            starting_message, details=["padding", DebugInfo(detail="key: 100")]
         )
         batch._append_context_to_error(err)
         self.assertEqual(
@@ -1810,7 +1810,7 @@ class TestBatch(unittest.TestCase):
         client = _Client(project=self.PROJECT)
         starting_message = "hello"
         exception = InvalidArgument(
-            starting_message, details=[DebugInfo(detail=f"key: 1")]
+            starting_message, details=[DebugInfo(detail="key: 1")]
         )
         client.logging_api = _DummyLoggingExceptionAPI(exception)
         batch = self._make_one(logger, client=client)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1697,6 +1697,65 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch.entries), UNSENT)
         self.assertIsNone(api._write_entries_called_with)
 
+    def test_append_context_to_error(self):
+        """
+        If an InvalidArgument exception contains info on the log that threw it,
+        we should be able to add it to the exceptiom message. If not, the
+        exception should be unchanged
+        """
+        from google.api_core.exceptions import InvalidArgument
+        from google.rpc.error_details_pb2 import DebugInfo
+        from google.cloud.logging import TextEntry
+        logger = _Logger()
+        client = _Client(project=self.PROJECT)
+        batch = self._make_one(logger, client=client)
+        test_entries = [TextEntry(payload=str(i)) for i in range(11)]
+        batch.entries = test_entries
+        starting_message = "test"
+        # test that properly formatted exceptions add log details
+        for idx, entry in enumerate(test_entries):
+            api_entry = entry.to_api_repr()
+            err = InvalidArgument(starting_message,
+                details=["padding", DebugInfo(detail=f"key: {idx}")])
+            batch._append_context_to_error(err)
+            self.assertEqual(err.message, f"{starting_message}: {str(api_entry)}...")
+            self.assertIn(str(idx), str(entry))
+        # test with missing debug info
+        err = InvalidArgument(starting_message, details=[])
+        batch._append_context_to_error(err)
+        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+        # test with missing key
+        err = InvalidArgument(starting_message,
+                details=["padding", DebugInfo(detail=f"no k e y here")])
+        batch._append_context_to_error(err)
+        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+        # test with key out of range
+        err = InvalidArgument(starting_message,
+                              details=["padding", DebugInfo(detail=f"key: 100")])
+        batch._append_context_to_error(err)
+        self.assertEqual(err.message, starting_message, "message should have been unchanged")
+
+    def test_batch_error_gets_context(self):
+        """
+        Simulate an InvalidArgument sent as part of a batch commit, to ensure
+        _append_context_to_error is thrown
+        """
+        from google.api_core.exceptions import InvalidArgument
+        from google.rpc.error_details_pb2 import DebugInfo
+        from google.cloud.logging import TextEntry
+        logger = _Logger()
+        client = _Client(project=self.PROJECT)
+        starting_message = "hello"
+        exception = InvalidArgument(starting_message, details=[DebugInfo(detail=f"key: 1")])
+        client.logging_api = _DummyLoggingExceptionAPI(exception)
+        batch = self._make_one(logger, client=client)
+        test_entries = [TextEntry(payload=str(i)) for i in range(11)]
+        batch.entries = test_entries
+        with self.assertRaises(InvalidArgument) as e:
+            batch.commit()
+            expected_log = test_entries[1]
+            api_entry = expected_log.to_api_repr()
+            self.assertEqual(e.message, f"{starting_message}: {str(api_entry)}...")
 
 class _Logger(object):
 
@@ -1724,6 +1783,25 @@ class _DummyLoggingAPI(object):
     def logger_delete(self, logger_name):
         self._logger_delete_called_with = logger_name
 
+
+class _DummyLoggingExceptionAPI(object):
+
+    def __init__(self, exception):
+        self.exception = exception
+
+    def write_entries(
+        self,
+        entries,
+        *,
+        logger_name=None,
+        resource=None,
+        labels=None,
+        partial_success=False,
+    ):
+        raise self.exception
+
+    def logger_delete(self, logger_name):
+        raise self.exception
 
 class _Client(object):
     def __init__(self, project, connection=None):


### PR DESCRIPTION
Sometimes, a log may fail as part of a larger batch of logs (eg, due to payload size). These exceptions can be hard to track down, because batches happen asynchronously on a background thread

This PR attempts to help resolve the issue by adding a truncated copy of the failing log to the batch log exception message

```
  File "router.py", line 86, in pubsub_callback
    found_func(**kwargs)
  File "/app/snippets.py", line 81, in batch_large_log
    batch.commit()
  File "/app/python-logging/google/cloud/logging_v2/logger.py", line 470, in commit
    raise e
  File "/app/python-logging/google/cloud/logging_v2/logger.py", line 465, in commit
    client.logging_api.write_entries(entries, partial_success=True, **kwargs)
  File "/app/python-logging/google/cloud/logging_v2/_gapic.py", line 160, in write_entries
    self._gapic_api.write_log_entries(request=request)
  File "/app/python-logging/google/cloud/logging_v2/services/logging_service_v2/client.py", line 725, in write_log_entries
    metadata=metadata,
  File "/usr/local/lib/python3.7/site-packages/google/api_core/gapic_v1/method.py", line 154, in __call__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 288, in retry_wrapped_func
    on_error=on_error,
  File "/usr/local/lib/python3.7/site-packages/google/api_core/retry.py", line 190, in retry_target
    return target()
  File "/usr/local/lib/python3.7/site-packages/google/api_core/grpc_helpers.py", line 74, in error_remapped_callable
    raise exceptions.from_grpc_error(exc) from exc
google.api_core.exceptions.InvalidArgument: 400 Log entry with size 263.8K exceeds maximum size of 256.0K: StructEntry(log_name=None, labels=None, insert_id=None, severity='DEFAULT', http_request=None, timestamp=None, resource=Resource(type='global', labels={}), trace=None, span_id=None, trace_sampled=None, source_location=None, operation=None, logger=None, payload={'message': 'simple_log', 'buffer': '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000... [type_url: "type.googleapis.com/google.logging.v2.WriteLogEntriesPartialErrors"
value: "\nA\010\007\022=\010\003\0229Log entry with size 263.8K exceeds maximum size of 256.0K"
, detail: "[ORIGINAL ERROR] generic::invalid_argument: Log entry with size 263.8K exceeds maximum size of 256.0K [google.rpc.error_details_ext] { message: \"Log entry with size 263.8K exceeds maximum size of 256.0K\" details { [type.googleapis.com/google.logging.v2.WriteLogEntriesPartialErrors] { log_entry_errors { key: 7 value { code: 3 message: \"Log entry with size 263.8K exceeds maximum size of 256.0K\" } } } } }"
]

```

Fixes: https://github.com/googleapis/python-logging/issues/53