### PR TITLE
feat: Generate a copy of json_fields before adding message

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -252,6 +252,7 @@ def _format_and_parse_message(record, formatter_handler):
         pass
     # if json_fields was set, create a dictionary using that
     if passed_json_fields and isinstance(passed_json_fields, collections.abc.Mapping):
+        passed_json_fields = passed_json_fields.copy()
         if message != "None":
             passed_json_fields["message"] = message
         return passed_json_fields


### PR DESCRIPTION
We had a problem where we wanted to log a payload to another service via "json_fields", however, the logging handler added the key "message" to the payload so we started having errors. I propose to generate a copy of the json_fields instead of using the user supplied one.

I made a copy before the message is added to the dictionary.

Fixes #652
