### PR TITLE
chore: fix environment tests by changing uuid generation

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -65,7 +65,7 @@ if [[ "${ENVIRONMENT}" == "kubernetes" ]]; then
 fi
 
 # create a unique id for this run
-UUID=$(python  -c 'import uuid; print(uuid.uuid1())' | head -c 7)
+UUID=$(python -c 'import uuid; print(str(uuid.uuid1())[:7])')
 export ENVCTL_ID=ci-$UUID
 echo $ENVCTL_ID
 


### PR DESCRIPTION
Environment tests are currently failing due to a broken pipe. This PR changes how the uuid is generated to avoid the issue
