### PR TITLE
fix: client_info default values

### DIFF
--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -564,20 +564,22 @@ def _log_entry_mapping_to_pb(mapping):
     ParseDict(mapping, entry_pb)
     return LogEntryPB(entry_pb)
 
+
 def _client_info_to_gapic(input_info):
     """
-    Helper function to convert api_core.client_info to 
+    Helper function to convert api_core.client_info to
     api_core.gapic_v1.client_info subclass
     """
     return gapic_v1.client_info.ClientInfo(
         python_version=input_info.python_version,
-        grpc_version = input_info.grpc_version,
-        api_core_version = input_info.api_core_version,
-        gapic_version = input_info.gapic_version,
-        client_library_version = input_info.client_library_version,
-        user_agent = input_info.user_agent,
-        rest_version = input_info.rest_version,
+        grpc_version=input_info.grpc_version,
+        api_core_version=input_info.api_core_version,
+        gapic_version=input_info.gapic_version,
+        client_library_version=input_info.client_library_version,
+        user_agent=input_info.user_agent,
+        rest_version=input_info.rest_version,
     )
+
 
 def make_logging_api(client):
     """Create an instance of the Logging API adapter.
@@ -590,7 +592,9 @@ def make_logging_api(client):
         _LoggingAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
+        info, client_info.ClientInfo
+    ):
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 
@@ -613,7 +617,9 @@ def make_metrics_api(client):
         _MetricsAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
+        info, client_info.ClientInfo
+    ):
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 
@@ -636,7 +642,9 @@ def make_sinks_api(client):
         _SinksAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
+        info, client_info.ClientInfo
+    ):
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -592,9 +592,7 @@ def make_logging_api(client):
         _LoggingAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
-        info, client_info.ClientInfo
-    ):
+    if type(info) == client_info.ClientInfo:
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 
@@ -617,9 +615,7 @@ def make_metrics_api(client):
         _MetricsAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
-        info, client_info.ClientInfo
-    ):
+    if type(info) == client_info.ClientInfo:
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 
@@ -642,9 +638,7 @@ def make_sinks_api(client):
         _SinksAPI: A metrics API instance with the proper credentials.
     """
     info = client._client_info
-    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(
-        info, client_info.ClientInfo
-    ):
+    if type(info) == client_info.ClientInfo:
         # convert into gapic-compatible subclass
         info = _client_info_to_gapic(info)
 

--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -35,6 +35,9 @@ from google.cloud.logging_v2._helpers import entry_from_resource
 from google.cloud.logging_v2.sink import Sink
 from google.cloud.logging_v2.metric import Metric
 
+from google.api_core import client_info
+from google.api_core import gapic_v1
+
 
 class _LoggingAPI(object):
     """Helper mapping logging-related APIs."""
@@ -561,6 +564,20 @@ def _log_entry_mapping_to_pb(mapping):
     ParseDict(mapping, entry_pb)
     return LogEntryPB(entry_pb)
 
+def _client_info_to_gapic(input_info):
+    """
+    Helper function to convert api_core.client_info to 
+    api_core.gapic_v1.client_info subclass
+    """
+    return gapic_v1.client_info.ClientInfo(
+        python_version=input_info.python_version,
+        grpc_version = input_info.grpc_version,
+        api_core_version = input_info.api_core_version,
+        gapic_version = input_info.gapic_version,
+        client_library_version = input_info.client_library_version,
+        user_agent = input_info.user_agent,
+        rest_version = input_info.rest_version,
+    )
 
 def make_logging_api(client):
     """Create an instance of the Logging API adapter.
@@ -572,9 +589,14 @@ def make_logging_api(client):
     Returns:
         _LoggingAPI: A metrics API instance with the proper credentials.
     """
+    info = client._client_info
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+        # convert into gapic-compatible subclass
+        info = _client_info_to_gapic(info)
+
     generated = LoggingServiceV2Client(
         credentials=client._credentials,
-        client_info=client._client_info,
+        client_info=info,
         client_options=client._client_options,
     )
     return _LoggingAPI(generated, client)
@@ -590,9 +612,14 @@ def make_metrics_api(client):
     Returns:
         _MetricsAPI: A metrics API instance with the proper credentials.
     """
+    info = client._client_info
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+        # convert into gapic-compatible subclass
+        info = _client_info_to_gapic(info)
+
     generated = MetricsServiceV2Client(
         credentials=client._credentials,
-        client_info=client._client_info,
+        client_info=info,
         client_options=client._client_options,
     )
     return _MetricsAPI(generated, client)
@@ -608,9 +635,14 @@ def make_sinks_api(client):
     Returns:
         _SinksAPI: A metrics API instance with the proper credentials.
     """
+    info = client._client_info
+    if (not isinstance(info, gapic_v1.client_info.ClientInfo)) and isinstance(info, client_info.ClientInfo):
+        # convert into gapic-compatible subclass
+        info = _client_info_to_gapic(info)
+
     generated = ConfigServiceV2Client(
         credentials=client._credentials,
-        client_info=client._client_info,
+        client_info=info,
         client_options=client._client_options,
     )
     return _SinksAPI(generated, client)

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -137,6 +137,10 @@ class Client(ClientWithProject):
                 kw_args["api_endpoint"] = api_endpoint
 
         self._connection = Connection(self, **kw_args)
+        if client_info is None:
+            # if client info not passed in, use the discovered
+            # client info from _connection object
+            client_info = self._connection._client_info
 
         self._client_info = client_info
         self._client_options = client_options

--- a/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -98,16 +98,23 @@ def test__get_default_mtls_endpoint():
         ConfigServiceV2Client._get_default_mtls_endpoint(non_googleapi) == non_googleapi
     )
 
+
 def test_config_default_client_info_headers():
     import re
     import pkg_resources
+
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
     # go/cloud-api-headers-2019
-    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
-    detected_info = google.cloud.logging_v2.services.config_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    gapic_header_regex = re.compile(
+        r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
+    )
+    detected_info = (
+        google.cloud.logging_v2.services.config_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    )
     assert detected_info is not None
     detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
     assert gapic_header_regex.match(detected_agent)
+
 
 @pytest.mark.parametrize(
     "client_class,transport_name",

--- a/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -98,6 +98,16 @@ def test__get_default_mtls_endpoint():
         ConfigServiceV2Client._get_default_mtls_endpoint(non_googleapi) == non_googleapi
     )
 
+def test_config_default_client_info_headers():
+    import re
+    import pkg_resources
+    # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
+    # go/cloud-api-headers-2019
+    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
+    detected_info = google.cloud.logging_v2.services.config_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    assert detected_info is not None
+    detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
+    assert gapic_header_regex.match(detected_agent)
 
 @pytest.mark.parametrize(
     "client_class,transport_name",

--- a/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -104,7 +104,6 @@ def test_config_default_client_info_headers():
     import pkg_resources
 
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
-    # go/cloud-api-headers-2019
     gapic_header_regex = re.compile(
         r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
     )

--- a/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -70,6 +70,16 @@ def modify_default_endpoint(client):
         else client.DEFAULT_ENDPOINT
     )
 
+def test_logging_default_client_info_headers():
+    import re
+    import pkg_resources
+    # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
+    # go/cloud-api-headers-2019
+    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
+    detected_info = google.cloud.logging_v2.services.logging_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    assert detected_info is not None
+    detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
+    assert gapic_header_regex.match(detected_agent)
 
 def test__get_default_mtls_endpoint():
     api_endpoint = "example.googleapis.com"

--- a/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -70,16 +70,23 @@ def modify_default_endpoint(client):
         else client.DEFAULT_ENDPOINT
     )
 
+
 def test_logging_default_client_info_headers():
     import re
     import pkg_resources
+
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
     # go/cloud-api-headers-2019
-    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
-    detected_info = google.cloud.logging_v2.services.logging_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    gapic_header_regex = re.compile(
+        r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
+    )
+    detected_info = (
+        google.cloud.logging_v2.services.logging_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    )
     assert detected_info is not None
     detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
     assert gapic_header_regex.match(detected_agent)
+
 
 def test__get_default_mtls_endpoint():
     api_endpoint = "example.googleapis.com"

--- a/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -76,7 +76,6 @@ def test_logging_default_client_info_headers():
     import pkg_resources
 
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
-    # go/cloud-api-headers-2019
     gapic_header_regex = re.compile(
         r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
     )

--- a/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -104,7 +104,6 @@ def test_metrics_default_client_info_headers():
     import pkg_resources
 
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
-    # go/cloud-api-headers-2019
     gapic_header_regex = re.compile(
         r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
     )

--- a/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -98,16 +98,23 @@ def test__get_default_mtls_endpoint():
         == non_googleapi
     )
 
+
 def test_metrics_default_client_info_headers():
     import re
     import pkg_resources
+
     # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
     # go/cloud-api-headers-2019
-    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
-    detected_info = google.cloud.logging_v2.services.metrics_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    gapic_header_regex = re.compile(
+        r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
+    )
+    detected_info = (
+        google.cloud.logging_v2.services.metrics_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    )
     assert detected_info is not None
     detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
     assert gapic_header_regex.match(detected_agent)
+
 
 @pytest.mark.parametrize(
     "client_class,transport_name",

--- a/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -98,6 +98,16 @@ def test__get_default_mtls_endpoint():
         == non_googleapi
     )
 
+def test_metrics_default_client_info_headers():
+    import re
+    import pkg_resources
+    # test that DEFAULT_CLIENT_INFO contains the expected gapic headers
+    # go/cloud-api-headers-2019
+    gapic_header_regex = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
+    detected_info = google.cloud.logging_v2.services.metrics_service_v2.transports.base.DEFAULT_CLIENT_INFO
+    assert detected_info is not None
+    detected_agent = " ".join(sorted(detected_info.to_user_agent().split(" ")))
+    assert gapic_header_regex.match(detected_agent)
 
 @pytest.mark.parametrize(
     "client_class,transport_name",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -151,6 +151,9 @@ class TestClient(unittest.TestCase):
         self.assertIs(again, api)
 
     def test_veneer_grpc_headers(self):
+        # test that client APIs have client_info populated with the expected veneer headers
+        # required for proper instrumentation
+        # go/cloud-api-headers-2019
         creds = _make_credentials()
         # ensure client info is set on client object
         client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=True)
@@ -173,13 +176,20 @@ class TestClient(unittest.TestCase):
                 self.assertTrue(VENEER_HEADER_REGEX.match(wrapped_user_agent_sorted))
 
     def test_veneer_http_headers(self):
+        # test that http APIs have client_info populated with the expected veneer headers
+        # required for proper instrumentation
+        # go/cloud-api-headers-2019
         creds = _make_credentials()
-        patch = mock.patch("google.api_core.gapic_v1.method.wrap_method")
-        with patch as http_mock:
-            client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=False)
-            user_agent = client._connection._client_info.to_user_agent()
-            user_agent_sorted = " ".join(sorted(user_agent.split(" ")))
-            self.assertTrue(VENEER_HEADER_REGEX.match(user_agent_sorted))
+        # ensure client info is set on client object
+        client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=False)
+        self.assertIsNotNone(client._client_info)
+        user_agent_sorted = " ".join(sorted(client._client_info.to_user_agent().split(" ")))
+        self.assertTrue(VENEER_HEADER_REGEX.match(user_agent_sorted))
+        # ensure client info is propagated to _connection object
+        connection_user_agent = client._connection._client_info.to_user_agent()
+        self.assertIsNotNone(connection_user_agent)
+        connection_user_agent_sorted = " ".join(sorted(connection_user_agent.split(" ")))
+        self.assertTrue(VENEER_HEADER_REGEX.match(connection_user_agent_sorted))
 
     def test_no_gapic_ctor(self):
         from google.cloud.logging_v2._http import _LoggingAPI

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -156,7 +156,6 @@ class TestClient(unittest.TestCase):
     def test_veneer_grpc_headers(self):
         # test that client APIs have client_info populated with the expected veneer headers
         # required for proper instrumentation
-        # go/cloud-api-headers-2019
         creds = _make_credentials()
         # ensure client info is set on client object
         client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=True)
@@ -189,7 +188,6 @@ class TestClient(unittest.TestCase):
     def test_veneer_http_headers(self):
         # test that http APIs have client_info populated with the expected veneer headers
         # required for proper instrumentation
-        # go/cloud-api-headers-2019
         creds = _make_credentials()
         # ensure client info is set on client object
         client = self._make_one(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -22,7 +22,10 @@ import unittest
 
 import mock
 
-VENEER_HEADER_REGEX = re.compile(r'gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gccl\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+')
+VENEER_HEADER_REGEX = re.compile(
+    r"gapic\/[0-9]+\.[\w.-]+ gax\/[0-9]+\.[\w.-]+ gccl\/[0-9]+\.[\w.-]+ gl-python\/[0-9]+\.[\w.-]+ grpc\/[0-9]+\.[\w.-]+"
+)
+
 
 def _make_credentials():
     import google.auth.credentials
@@ -158,21 +161,29 @@ class TestClient(unittest.TestCase):
         # ensure client info is set on client object
         client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=True)
         self.assertIsNotNone(client._client_info)
-        user_agent_sorted = " ".join(sorted(client._client_info.to_user_agent().split(" ")))
+        user_agent_sorted = " ".join(
+            sorted(client._client_info.to_user_agent().split(" "))
+        )
         self.assertTrue(VENEER_HEADER_REGEX.match(user_agent_sorted))
         # ensure client info is propagated to gapic wrapped methods
         patch = mock.patch("google.api_core.gapic_v1.method.wrap_method")
         with patch as gapic_mock:
-            client.logging_api # initialize logging api
-            client.metrics_api # initialize metrics api
-            client.sinks_api # initialize sinks api
+            client.logging_api  # initialize logging api
+            client.metrics_api  # initialize metrics api
+            client.sinks_api  # initialize sinks api
             wrapped_call_list = gapic_mock.call_args_list
-            num_api_calls = 37 # expected number of distinct APIs in all gapic services (logging,metrics,sinks)
-            self.assertGreaterEqual(len(wrapped_call_list), num_api_calls, "unexpected number of APIs wrapped")
+            num_api_calls = 37  # expected number of distinct APIs in all gapic services (logging,metrics,sinks)
+            self.assertGreaterEqual(
+                len(wrapped_call_list),
+                num_api_calls,
+                "unexpected number of APIs wrapped",
+            )
             for call in wrapped_call_list:
                 client_info = call.kwargs["client_info"]
                 self.assertIsNotNone(client_info)
-                wrapped_user_agent_sorted = " ".join(sorted(client_info.to_user_agent().split(" ")))
+                wrapped_user_agent_sorted = " ".join(
+                    sorted(client_info.to_user_agent().split(" "))
+                )
                 self.assertTrue(VENEER_HEADER_REGEX.match(wrapped_user_agent_sorted))
 
     def test_veneer_http_headers(self):
@@ -181,14 +192,20 @@ class TestClient(unittest.TestCase):
         # go/cloud-api-headers-2019
         creds = _make_credentials()
         # ensure client info is set on client object
-        client = self._make_one(project=self.PROJECT, credentials=creds, _use_grpc=False)
+        client = self._make_one(
+            project=self.PROJECT, credentials=creds, _use_grpc=False
+        )
         self.assertIsNotNone(client._client_info)
-        user_agent_sorted = " ".join(sorted(client._client_info.to_user_agent().split(" ")))
+        user_agent_sorted = " ".join(
+            sorted(client._client_info.to_user_agent().split(" "))
+        )
         self.assertTrue(VENEER_HEADER_REGEX.match(user_agent_sorted))
         # ensure client info is propagated to _connection object
         connection_user_agent = client._connection._client_info.to_user_agent()
         self.assertIsNotNone(connection_user_agent)
-        connection_user_agent_sorted = " ".join(sorted(connection_user_agent.split(" ")))
+        connection_user_agent_sorted = " ".join(
+            sorted(connection_user_agent.split(" "))
+        )
         self.assertTrue(VENEER_HEADER_REGEX.match(connection_user_agent_sorted))
 
     def test_no_gapic_ctor(self):


### PR DESCRIPTION
When client_info is not given to a new client, it now defaults to the values used by `self._connection._client_info`, rather than using None. This will allow the expected headers to be populated when using the grpc transport

Also added tests to ensure client_info is always set as expected in all classes

Fixes https://github.com/googleapis/python-logging/issues/680
