### PR TITLE
fix: instrumentation entries should not contain user labels

### DIFF
--- a/google/cloud/logging_v2/_instrumentation.py
+++ b/google/cloud/logging_v2/_instrumentation.py
@@ -27,7 +27,7 @@ _MAX_VERSION_LENGTH = 14
 _MAX_INSTRUMENTATION_ENTRIES = 3
 
 
-def _add_instrumentation(entries, **kw):
+def _add_instrumentation(entries, project_id):
     """Add instrumentation information to a list of entries
 
         A new diagnostic entry is prepended to the list of
@@ -36,18 +36,18 @@ def _add_instrumentation(entries, **kw):
     Args:
        entries (Sequence[Mapping[str, ...]]): sequence of mappings representing
             the log entry resources to log.
+        project_id (str): The project to associate the diagnostic with
 
     Returns:
         Sequence[Mapping[str, ...]]: entries with instrumentation info added to
         the beginning of list.
     """
-
-    diagnostic_entry = _create_diagnostic_entry(**kw)
+    diagnostic_entry = _create_diagnostic_entry(project_id)
     entries.insert(0, diagnostic_entry.to_api_repr())
     return entries
 
 
-def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION, **kw):
+def _create_diagnostic_entry(project_id=None, name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION):
     """Create a diagnostic log entry describing this library
 
         The diagnostic log consists of a list of library name and version objects
@@ -56,6 +56,7 @@ def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
         {logging.googleapis.com/diagnostic: {instrumentation_source: [{name: "python", version: "3.0.0"}]}}
 
     Args:
+        project_id(str): The project to associate the diagnostic with
         name(str): The name of this library (e.g. 'python')
         version(str) The version of this library (e.g. '3.0.0')
 
@@ -67,7 +68,11 @@ def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
             _INSTRUMENTATION_SOURCE_KEY: [_get_instrumentation_source(name, version)]
         }
     }
-    entry = StructEntry(payload=payload, severity="INFO")
+    if project_id is None:
+        log_name = _DIAGNOSTIC_INFO_KEY
+    else:
+        log_name = f"projects/{project_id}/logs/{_DIAGNOSTIC_INFO_KEY}"
+    entry = StructEntry(payload=payload, severity="INFO", log_name=log_name)
     return entry
 
 

--- a/google/cloud/logging_v2/_instrumentation.py
+++ b/google/cloud/logging_v2/_instrumentation.py
@@ -67,8 +67,7 @@ def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
             _INSTRUMENTATION_SOURCE_KEY: [_get_instrumentation_source(name, version)]
         }
     }
-    kw["severity"] = "INFO"
-    entry = StructEntry(payload=payload, **kw)
+    entry = StructEntry(payload=payload, severity="INFO")
     return entry
 
 

--- a/google/cloud/logging_v2/_instrumentation.py
+++ b/google/cloud/logging_v2/_instrumentation.py
@@ -47,7 +47,9 @@ def _add_instrumentation(entries, project_id):
     return entries
 
 
-def _create_diagnostic_entry(project_id=None, name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION):
+def _create_diagnostic_entry(
+    project_id=None, name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
+):
     """Create a diagnostic log entry describing this library
 
         The diagnostic log consists of a list of library name and version objects

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -162,7 +162,7 @@ class Logger(object):
         api_repr = entry.to_api_repr()
         entries = [api_repr]
         if google.cloud.logging_v2._instrumentation_emitted is False:
-            entries = _add_instrumentation(entries, **kw)
+            entries = _add_instrumentation(entries, self.project)
             google.cloud.logging_v2._instrumentation_emitted = True
         # partial_success is true to avoid dropping instrumentation logs
         client.logging_api.write_entries(entries, partial_success=True)

--- a/tests/unit/test__instrumentation.py
+++ b/tests/unit/test__instrumentation.py
@@ -42,9 +42,7 @@ class TestInstrumentation(unittest.TestCase):
         self.assertEqual(
             i._LIBRARY_VERSION, self._get_diagonstic_value(entry, "version")
         )
-        self.assertEqual(
-            i._DIAGNOSTIC_INFO_KEY, entry.log_name
-        )
+        self.assertEqual(i._DIAGNOSTIC_INFO_KEY, entry.log_name)
 
     def test_custom_diagnostic_info(self):
         entry = i._create_diagnostic_entry(
@@ -58,7 +56,8 @@ class TestInstrumentation(unittest.TestCase):
             self.TEST_VERSION, self._get_diagonstic_value(entry, "version")
         )
         self.assertEqual(
-            f"projects/{self.TEST_PROJECT}/logs/{i._DIAGNOSTIC_INFO_KEY}", entry.log_name
+            f"projects/{self.TEST_PROJECT}/logs/{i._DIAGNOSTIC_INFO_KEY}",
+            entry.log_name,
         )
 
     def test_truncate_long_values(self):

--- a/tests/unit/test__instrumentation.py
+++ b/tests/unit/test__instrumentation.py
@@ -26,6 +26,8 @@ class TestInstrumentation(unittest.TestCase):
     # LONG_VERSION > 16 characters
     LONG_VERSION = TEST_VERSION + "6789ABCDEF12"
 
+    TEST_PROJECT = "MY_PROJ"
+
     def _get_diagonstic_value(self, entry, key):
         return entry.payload[i._DIAGNOSTIC_INFO_KEY][i._INSTRUMENTATION_SOURCE_KEY][-1][
             key
@@ -40,10 +42,13 @@ class TestInstrumentation(unittest.TestCase):
         self.assertEqual(
             i._LIBRARY_VERSION, self._get_diagonstic_value(entry, "version")
         )
+        self.assertEqual(
+            i._DIAGNOSTIC_INFO_KEY, entry.log_name
+        )
 
     def test_custom_diagnostic_info(self):
         entry = i._create_diagnostic_entry(
-            name=self.TEST_NAME, version=self.TEST_VERSION
+            project_id=self.TEST_PROJECT, name=self.TEST_NAME, version=self.TEST_VERSION
         )
         self.assertEqual(
             self.TEST_NAME,
@@ -51,6 +56,9 @@ class TestInstrumentation(unittest.TestCase):
         )
         self.assertEqual(
             self.TEST_VERSION, self._get_diagonstic_value(entry, "version")
+        )
+        self.assertEqual(
+            f"projects/{self.TEST_PROJECT}/logs/{i._DIAGNOSTIC_INFO_KEY}", entry.log_name
         )
 
     def test_truncate_long_values(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1051,14 +1051,7 @@ class TestLogger(unittest.TestCase):
         google.cloud.logging_v2._instrumentation_emitted = False
         DEFAULT_LABELS = {"foo": "spam"}
         resource = detect_resource(self.PROJECT)
-        instrumentation_entry = _create_diagnostic_entry(
-            resource=resource,
-            labels=DEFAULT_LABELS,
-        ).to_api_repr()
-        instrumentation_entry["logName"] = "projects/%s/logs/%s" % (
-            self.PROJECT,
-            self.LOGGER_NAME,
-        )
+        instrumentation_entry = _create_diagnostic_entry().to_api_repr()
         ENTRIES = [
             instrumentation_entry,
             {

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1076,17 +1076,16 @@ class TestLogger(unittest.TestCase):
         )
 
     def test_instrumentation_uses_custom_logname(self):
-        from google.cloud.logging_v2.handlers._monitored_resources import (
-            detect_resource,
-        )
         from google.cloud.logging_v2._instrumentation import _create_diagnostic_entry
         import google.cloud.logging_v2
 
         google.cloud.logging_v2._instrumentation_emitted = False
         instrumentation_entry = _create_diagnostic_entry("PROJ")
         self.assertEqual(
-            "projects/PROJ/logs/logging.googleapis.com/diagnostic", instrumentation_entry.log_name
+            "projects/PROJ/logs/logging.googleapis.com/diagnostic",
+            instrumentation_entry.log_name,
         )
+
 
 class TestBatch(unittest.TestCase):
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1051,7 +1051,7 @@ class TestLogger(unittest.TestCase):
         google.cloud.logging_v2._instrumentation_emitted = False
         DEFAULT_LABELS = {"foo": "spam"}
         resource = detect_resource(self.PROJECT)
-        instrumentation_entry = _create_diagnostic_entry().to_api_repr()
+        instrumentation_entry = _create_diagnostic_entry(self.PROJECT).to_api_repr()
         ENTRIES = [
             instrumentation_entry,
             {
@@ -1075,6 +1075,18 @@ class TestLogger(unittest.TestCase):
             api._write_entries_called_with, (ENTRIES, None, None, None, True)
         )
 
+    def test_instrumentation_uses_custom_logname(self):
+        from google.cloud.logging_v2.handlers._monitored_resources import (
+            detect_resource,
+        )
+        from google.cloud.logging_v2._instrumentation import _create_diagnostic_entry
+        import google.cloud.logging_v2
+
+        google.cloud.logging_v2._instrumentation_emitted = False
+        instrumentation_entry = _create_diagnostic_entry("PROJ")
+        self.assertEqual(
+            "projects/PROJ/logs/logging.googleapis.com/diagnostic", instrumentation_entry.log_name
+        )
 
 class TestBatch(unittest.TestCase):
 


### PR DESCRIPTION
Previously, instrumentation logs would inherit labels and other log metadata from the parent log. This was causing issues when the user expected logs with certain labels to conform to a set structure, which the instrumentation log would break

Instead, instrumentation logs should be static, containing only a severity field
