### PR TITLE
fix: instrumentation entries should not contain user labels

### DIFF
--- a/google/cloud/logging_v2/_instrumentation.py
+++ b/google/cloud/logging_v2/_instrumentation.py
@@ -67,11 +67,9 @@ def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
             _INSTRUMENTATION_SOURCE_KEY: [_get_instrumentation_source(name, version)]
         }
     }
-    active_kws = {"severity": "INFO"}
     # only keep the log_name and resource from the parent log
-    for key in ["log_name", "resource"]:
-        if key in kw.keys():
-            active_kws[key] = kw[key]
+    allow_list = ("log_name", "resource")
+    active_kws = {k: v for k, v in kw.items() if k in allow_list}
     entry = StructEntry(payload=payload, **active_kws)
     return entry
 

--- a/google/cloud/logging_v2/_instrumentation.py
+++ b/google/cloud/logging_v2/_instrumentation.py
@@ -67,8 +67,12 @@ def _create_diagnostic_entry(name=_PYTHON_LIBRARY_NAME, version=_LIBRARY_VERSION
             _INSTRUMENTATION_SOURCE_KEY: [_get_instrumentation_source(name, version)]
         }
     }
-    kw["severity"] = "INFO"
-    entry = StructEntry(payload=payload, **kw)
+    active_kws = {"severity": "INFO"}
+    # only keep the log_name and resource from the parent log
+    for key in ["log_name", "resource"]:
+        if key in kw.keys():
+            active_kws[key] = kw[key]
+    entry = StructEntry(payload=payload, **active_kws)
     return entry
 
 

--- a/tests/unit/test__instrumentation.py
+++ b/tests/unit/test__instrumentation.py
@@ -69,7 +69,10 @@ class TestInstrumentation(unittest.TestCase):
         test_logname = "test-name"
         test_labels = {"hello": "world"}
         entry = i._create_diagnostic_entry(
-            name=self.LONG_NAME, version=self.LONG_VERSION, log_name=test_logname, labels=test_labels,
+            name=self.LONG_NAME,
+            version=self.LONG_VERSION,
+            log_name=test_logname,
+            labels=test_labels,
         )
         self.assertEqual(entry.log_name, test_logname)
         self.assertIsNone(entry.labels)

--- a/tests/unit/test__instrumentation.py
+++ b/tests/unit/test__instrumentation.py
@@ -63,3 +63,13 @@ class TestInstrumentation(unittest.TestCase):
 
         self.assertEqual(expected_name, self._get_diagonstic_value(entry, "name"))
         self.assertEqual(expected_version, self._get_diagonstic_value(entry, "version"))
+
+    def test_drop_labels(self):
+        """Labels should not be copied in instrumentation log"""
+        test_logname = "test-name"
+        test_labels = {"hello": "world"}
+        entry = i._create_diagnostic_entry(
+            name=self.LONG_NAME, version=self.LONG_VERSION, log_name=test_logname, labels=test_labels,
+        )
+        self.assertEqual(entry.log_name, test_logname)
+        self.assertIsNone(entry.labels)

--- a/tests/unit/test__instrumentation.py
+++ b/tests/unit/test__instrumentation.py
@@ -76,3 +76,6 @@ class TestInstrumentation(unittest.TestCase):
         )
         self.assertEqual(entry.log_name, test_logname)
         self.assertIsNone(entry.labels)
+        # ensure only expected fields exist in entry
+        expected_keys = set(["logName", "resource", "jsonPayload"])
+        self.assertEqual(set(entry.to_api_repr().keys()), expected_keys)


### PR DESCRIPTION
Previously, instrumentation logs would inherit labels and other log metadata from the parent log. This was causing issues when the user expected logs with certain labels to conform to a set structure, which the instrumentation log would break

Instead, instrumentation logs should be static, containing only a severity field
