### PR TITLE
fix: send StructuredLogHandler instrumentation log using an explicit logger

### DIFF
--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -131,4 +131,8 @@ class StructuredLogHandler(logging.StreamHandler):
     def emit_instrumentation_info(self):
         google.cloud.logging_v2._instrumentation_emitted = True
         diagnostic_object = _create_diagnostic_entry()
-        logging.info(diagnostic_object.payload)
+        struct_logger = logging.getLogger("logging.googleapis.com/diagnostic")
+        struct_logger.addHandler(self)
+        struct_logger.setLevel(logging.INFO)
+        struct_logger.info(diagnostic_object.payload)
+        struct_logger.handlers.clear()

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -131,7 +131,7 @@ class StructuredLogHandler(logging.StreamHandler):
     def emit_instrumentation_info(self):
         google.cloud.logging_v2._instrumentation_emitted = True
         diagnostic_object = _create_diagnostic_entry()
-        struct_logger = logging.getLogger("logging.googleapis.com/diagnostic")
+        struct_logger = logging.getLogger(__name__)
         struct_logger.addHandler(self)
         struct_logger.setLevel(logging.INFO)
         struct_logger.info(diagnostic_object.payload)

--- a/tests/unit/handlers/test_structured_log.py
+++ b/tests/unit/handlers/test_structured_log.py
@@ -624,7 +624,8 @@ class TestStructuredLogHandler(unittest.TestCase):
         import mock
         import json
 
-        with mock.patch.object(logging, "info") as mock_log:
+        logger = logging.getLogger("google.cloud.logging_v2.handlers.structured_log")
+        with mock.patch.object(logger, "info") as mock_log:
             handler = self._make_one()
             handler.emit_instrumentation_info()
             mock_log.assert_called_once()


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-logging/issues/704


> The StructuredLogHandler sends an instrumentation log in the following format:
> 
> `logging.info(diagnostic_object.payload)`
> 
> This uses the root logging instance, which may not contain a GCP Logging Handler, so the log may not make its way to GCP.

This PR addresses this by obtaining a fresh logger instance, connecting the active StructuredLogHandler object as a handler, and emitting the instrumentation that way. using this method, the instrumentation log will be reliably printed to stdout in the same format as the other logs