### PR TITLE
fix: properly handle None from metadata server

### DIFF
--- a/google/cloud/logging_v2/handlers/_monitored_resources.py
+++ b/google/cloud/logging_v2/handlers/_monitored_resources.py
@@ -71,8 +71,8 @@ def _create_functions_resource():
     resource = Resource(
         type="cloud_function",
         labels={
-            "project_id": project,
-            "function_name": function_name,
+            "project_id": project if project else "",
+            "function_name": function_name if function_name else "",
             "region": region.split("/")[-1] if region else "",
         },
     )
@@ -91,7 +91,7 @@ def _create_kubernetes_resource():
     resource = Resource(
         type="k8s_container",
         labels={
-            "project_id": project,
+            "project_id": project if project else "",
             "location": zone if zone else "",
             "cluster_name": cluster_name if cluster_name else "",
         },
@@ -110,7 +110,7 @@ def _create_compute_resource():
     resource = Resource(
         type="gce_instance",
         labels={
-            "project_id": project,
+            "project_id": project if project else "",
             "instance_id": instance if instance else "",
             "zone": zone if zone else "",
         },
@@ -128,7 +128,7 @@ def _create_cloud_run_resource():
     resource = Resource(
         type="cloud_run_revision",
         labels={
-            "project_id": project,
+            "project_id": project if project else "",
             "service_name": os.environ.get(_CLOUD_RUN_SERVICE_ID, ""),
             "revision_name": os.environ.get(_CLOUD_RUN_REVISION_ID, ""),
             "location": region.split("/")[-1] if region else "",
@@ -148,7 +148,7 @@ def _create_app_engine_resource():
     resource = Resource(
         type="gae_app",
         labels={
-            "project_id": project,
+            "project_id": project if project else "",
             "module_id": os.environ.get(_GAE_SERVICE_ENV, ""),
             "version_id": os.environ.get(_GAE_VERSION_ENV, ""),
             "zone": zone if zone else "",
@@ -164,7 +164,7 @@ def _create_global_resource(project):
     Returns:
         google.cloud.logging.Resource
     """
-    return Resource(type="global", labels={"project_id": project})
+    return Resource(type="global", labels={"project_id": project if project else ""})
 
 
 def detect_resource(project=""):

--- a/tests/unit/handlers/test__monitored_resources.py
+++ b/tests/unit/handlers/test__monitored_resources.py
@@ -16,7 +16,7 @@ import unittest
 
 import mock
 import os
-
+import functools
 
 from google.cloud.logging_v2.handlers._monitored_resources import (
     _create_functions_resource,
@@ -66,6 +66,20 @@ class Test_Create_Resources(unittest.TestCase):
         else:
             return None
 
+    def _mock_metadata_no_project(self, endpoint):
+        if (
+            endpoint == _monitored_resources._ZONE_ID
+            or endpoint == _monitored_resources._REGION_ID
+        ):
+            return self.LOCATION
+        elif (
+            endpoint == _monitored_resources._GKE_CLUSTER_NAME
+            or endpoint == _monitored_resources._GCE_INSTANCE_ID
+        ):
+            return self.NAME
+        else:
+            return None
+
     def setUp(self):
         os.environ.clear()
 
@@ -99,6 +113,19 @@ class Test_Create_Resources(unittest.TestCase):
             self.assertEqual(func_resource.labels["project_id"], self.PROJECT)
             self.assertEqual(func_resource.labels["function_name"], self.NAME)
             self.assertEqual(func_resource.labels["region"], self.LOCATION)
+
+    def test_functions_resource_no_name(self):
+        patch = mock.patch(
+            "google.cloud.logging_v2.handlers._monitored_resources.retrieve_metadata_server",
+            wraps=self._mock_metadata_no_project,
+        )
+        with patch:
+            func_resource = _create_functions_resource()
+
+            self.assertIsInstance(func_resource, Resource)
+            self.assertEqual(func_resource.type, "cloud_function")
+            self.assertEqual(func_resource.labels["project_id"], "")
+            self.assertEqual(func_resource.labels["function_name"], "")
 
     def test_create_kubernetes_resource(self):
 
@@ -169,6 +196,21 @@ class Test_Create_Resources(unittest.TestCase):
         self.assertEqual(resource.type, "global")
         self.assertEqual(resource.labels["project_id"], self.PROJECT)
 
+    def test_with_no_project_from_server(self):
+        """
+        Ensure project_id uses an empty string if not known
+        https://github.com/googleapis/python-logging/issues/710
+        """
+        patch = mock.patch(
+            "google.cloud.logging_v2.handlers._monitored_resources.retrieve_metadata_server",
+            wraps=self._mock_metadata_no_project,
+        )
+        with patch:
+            _global_resource_patched = functools.partial(_create_global_resource, None)
+            resource_fns = [_global_resource_patched, _create_app_engine_resource, _create_cloud_run_resource, _create_compute_resource, _create_kubernetes_resource, _create_functions_resource]
+            for fn in resource_fns:
+                resource = fn()
+                self.assertEqual(resource.labels["project_id"], "")
 
 class Test_Resource_Detection(unittest.TestCase):
 
@@ -186,6 +228,14 @@ class Test_Resource_Detection(unittest.TestCase):
     def _mock_gce_metadata(self, endpoint):
         if endpoint == _monitored_resources._GCE_INSTANCE_ID:
             return "TRUE"
+        else:
+            return None
+
+    def _mock_partial_metadata(self, endpoint):
+        if endpoint == _monitored_resources._ZONE_ID:
+            return "ZONE"
+        elif endpoint == _monitored_resources._GCE_INSTANCE_ID:
+            return "instance"
         else:
             return None
 
@@ -249,3 +299,19 @@ class Test_Resource_Detection(unittest.TestCase):
             resource = detect_resource(self.PROJECT)
             self.assertIsInstance(resource, Resource)
             self.assertEqual(resource.type, "global")
+
+    def test_detect_partial_data(self):
+        """
+        Test if the metadata server retrus partial data
+        """
+        patch = mock.patch(
+            "google.cloud.logging_v2.handlers._monitored_resources.retrieve_metadata_server",
+            wraps=self._mock_partial_metadata,
+        )
+        with patch:
+            resource = detect_resource(self.PROJECT)
+            self.assertIsInstance(resource, Resource)
+            self.assertEqual(resource.type, "gce_instance")
+            # project id not returned from metadata serve
+            # should be empty string
+            self.assertEqual(resource.labels["project_id"], "")

--- a/tests/unit/handlers/test__monitored_resources.py
+++ b/tests/unit/handlers/test__monitored_resources.py
@@ -207,10 +207,18 @@ class Test_Create_Resources(unittest.TestCase):
         )
         with patch:
             _global_resource_patched = functools.partial(_create_global_resource, None)
-            resource_fns = [_global_resource_patched, _create_app_engine_resource, _create_cloud_run_resource, _create_compute_resource, _create_kubernetes_resource, _create_functions_resource]
+            resource_fns = [
+                _global_resource_patched,
+                _create_app_engine_resource,
+                _create_cloud_run_resource,
+                _create_compute_resource,
+                _create_kubernetes_resource,
+                _create_functions_resource,
+            ]
             for fn in resource_fns:
                 resource = fn()
                 self.assertEqual(resource.labels["project_id"], "")
+
 
 class Test_Resource_Detection(unittest.TestCase):
 

--- a/tests/unit/handlers/test__monitored_resources.py
+++ b/tests/unit/handlers/test__monitored_resources.py
@@ -314,7 +314,7 @@ class Test_Resource_Detection(unittest.TestCase):
 
     def test_detect_partial_data(self):
         """
-        Test if the metadata server retrus partial data
+        Test case where the metadata server returns partial data
         """
         patch = mock.patch(
             "google.cloud.logging_v2.handlers._monitored_resources.retrieve_metadata_server",

--- a/tests/unit/handlers/test__monitored_resources.py
+++ b/tests/unit/handlers/test__monitored_resources.py
@@ -115,6 +115,10 @@ class Test_Create_Resources(unittest.TestCase):
             self.assertEqual(func_resource.labels["region"], self.LOCATION)
 
     def test_functions_resource_no_name(self):
+        """
+        Simulate functions environment with function name returned as None
+        https://github.com/googleapis/python-logging/pull/718
+        """
         patch = mock.patch(
             "google.cloud.logging_v2.handlers._monitored_resources.retrieve_metadata_server",
             wraps=self._mock_metadata_no_project,
@@ -207,10 +211,18 @@ class Test_Create_Resources(unittest.TestCase):
         )
         with patch:
             _global_resource_patched = functools.partial(_create_global_resource, None)
-            resource_fns = [_global_resource_patched, _create_app_engine_resource, _create_cloud_run_resource, _create_compute_resource, _create_kubernetes_resource, _create_functions_resource]
+            resource_fns = [
+                _global_resource_patched,
+                _create_app_engine_resource,
+                _create_cloud_run_resource,
+                _create_compute_resource,
+                _create_kubernetes_resource,
+                _create_functions_resource,
+            ]
             for fn in resource_fns:
                 resource = fn()
                 self.assertEqual(resource.labels["project_id"], "")
+
 
 class Test_Resource_Detection(unittest.TestCase):
 


### PR DESCRIPTION
The library doesn't properly handle partial data from the metadata server. If the server returns some values, but None for others, the library will raise an error when it tries to log the None values

This PR addresses this by returning empty strings for any missing values, rather than None

Fixes https://github.com/googleapis/python-logging/issues/710
