### PR TITLE
fix: Handle exceptions raised when fetching Django request data

### DIFF
--- a/google/cloud/logging_v2/handlers/_helpers.py
+++ b/google/cloud/logging_v2/handlers/_helpers.py
@@ -104,10 +104,17 @@ def get_request_data_from_django():
     if request is None:
         return None, None, None, False
 
+    # Django can raise django.core.exceptions.DisallowedHost here for a
+    # malformed HTTP_HOST header. But we don't want to import Django modules.
+    try:
+        request_url = request.build_absolute_uri()
+    except Exception:
+        request_url = None
+
     # build http_request
     http_request = {
         "requestMethod": request.method,
-        "requestUrl": request.build_absolute_uri(),
+        "requestUrl": request_url,
         "userAgent": request.META.get(_DJANGO_USERAGENT_HEADER),
         "protocol": request.META.get(_PROTOCOL_HEADER),
     }

--- a/tests/unit/handlers/test__helpers.py
+++ b/tests/unit/handlers/test__helpers.py
@@ -242,6 +242,19 @@ class Test_get_request_data_from_django(unittest.TestCase):
         self.assertEqual(http_request["requestUrl"], expected_path)
         self.assertEqual(http_request["protocol"], "HTTP/1.1")
 
+    def test_invalid_host_header(self):
+        from django.test import RequestFactory
+        from google.cloud.logging_v2.handlers.middleware import request
+
+        invalid_http_host = "testserver%7d"
+        django_request = RequestFactory().put("/", HTTP_HOST=invalid_http_host)
+        middleware = request.RequestMiddleware(None)
+        middleware(django_request)
+        http_request, *_ = self._call_fut()
+        self.assertEqual(http_request["requestMethod"], "PUT")
+        self.assertIsNone(http_request["requestUrl"])
+        self.assertEqual(http_request["protocol"], "HTTP/1.1")
+
 
 class Test_get_request_data(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
The Django helper calls `request.build_absolute_uri()`, but that may raise a DisallowedHost exception itself. Instead we catch any exception and log `None` as the URL.

Fixes #757 
