### PR TITLE
fix: Ignore Python37DeprecationWarnings from google.auth

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,5 @@ filterwarnings =
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:tests.unit.test_entries
     # Remove once a version of grpcio newer than 1.59.3 is released to PyPI
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:grpc._channel
+    # Remove after support for Python 3.7 is dropped
+    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning


### PR DESCRIPTION
Ignore `Python37DeprecationWarning` from google.auth so that 3.7 unit tests may pass.

Fixes #822 

BEGIN_COMMIT_OVERRIDE
build: Ignore Python37DeprecationWarnings from google.auth
END_COMMIT_OVERRIDE
