### PR TITLE
fix: Fixed DeprecationWarning for datetime objects for Python 3.12

### DIFF
--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -240,7 +240,7 @@ class _Worker(object):
         queue_entry = {
             "message": message,
             "severity": _helpers._normalize_severity(record.levelno),
-            "timestamp": datetime.datetime.utcfromtimestamp(record.created),
+            "timestamp": datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc),
         }
         queue_entry.update(kwargs)
         self._queue.put_nowait(queue_entry)

--- a/google/cloud/logging_v2/handlers/transports/background_thread.py
+++ b/google/cloud/logging_v2/handlers/transports/background_thread.py
@@ -240,7 +240,9 @@ class _Worker(object):
         queue_entry = {
             "message": message,
             "severity": _helpers._normalize_severity(record.levelno),
-            "timestamp": datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc),
+            "timestamp": datetime.datetime.fromtimestamp(
+                record.created, datetime.timezone.utc
+            ),
         }
         queue_entry.update(kwargs)
         self._queue.put_nowait(queue_entry)

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,10 +13,6 @@ filterwarnings =
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
     # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
-    # Remove once https://github.com/googleapis/python-logging/issues/818 is fixed
-    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:google.cloud.logging_v2.handlers.transports
-    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:tests.unit.test__http
-    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:tests.unit.test_entries
     # Remove once a version of grpcio newer than 1.59.3 is released to PyPI
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:grpc._channel
     # Remove after support for Python 3.7 is dropped

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -336,7 +336,7 @@ class TestLogging(unittest.TestCase):
         text_payload = "System test: test_log_text_with_timestamp"
         gapic_logger = Config.CLIENT.logger(self._logger_name("log_text_ts"))
         http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_ts_http"))
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         loggers = (
             [gapic_logger]
             if Config.use_mtls == "always"
@@ -356,7 +356,7 @@ class TestLogging(unittest.TestCase):
 
         gapic_logger = Config.CLIENT.logger(self._logger_name("log_text_res"))
         http_logger = Config.HTTP_CLIENT.logger(self._logger_name("log_text_res_http"))
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         loggers = (
             [gapic_logger]
             if Config.use_mtls == "always"

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -122,9 +122,9 @@ class Test_LoggingAPI(unittest.TestCase):
     @staticmethod
     def _make_timestamp():
         import datetime
-        from google.cloud._helpers import UTC
+        from datetime import timezone
 
-        NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        NOW = datetime.datetime.now(timezone.utc)
         return NOW, _datetime_to_rfc3339_w_nanos(NOW)
 
     def test_list_entries_with_limits(self):

--- a/tests/unit/test_entries.py
+++ b/tests/unit/test_entries.py
@@ -200,14 +200,14 @@ class TestLogEntry(unittest.TestCase):
 
     def test_from_api_repr_w_loggers_no_logger_match(self):
         from datetime import datetime
-        from google.cloud._helpers import UTC
+        from datetime import timezone
         from google.cloud.logging import Resource
 
         klass = self._get_target_class()
         client = _Client(self.PROJECT)
         SEVERITY = "CRITICAL"
         IID = "IID"
-        NOW = datetime.utcnow().replace(tzinfo=UTC)
+        NOW = datetime.now(timezone.utc)
         TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
         LOG_NAME = "projects/%s/logs/%s" % (self.PROJECT, self.LOGGER_NAME)
         LABELS = {"foo": "bar", "baz": "qux"}
@@ -283,11 +283,11 @@ class TestLogEntry(unittest.TestCase):
     def test_from_api_repr_w_loggers_w_logger_match(self):
         from datetime import datetime
         from datetime import timedelta
-        from google.cloud._helpers import UTC
+        from datetime import timezone
 
         client = _Client(self.PROJECT)
         IID = "IID"
-        NOW = datetime.utcnow().replace(tzinfo=UTC)
+        NOW = datetime.now(timezone.utc)
         LATER = NOW + timedelta(seconds=1)
         TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
         RECEIVED = _datetime_to_rfc3339_w_nanos(LATER)
@@ -341,11 +341,11 @@ class TestLogEntry(unittest.TestCase):
     def test_from_api_repr_w_folder_path(self):
         from datetime import datetime
         from datetime import timedelta
-        from google.cloud._helpers import UTC
+        from datetime import timezone
 
         client = _Client(self.PROJECT)
         IID = "IID"
-        NOW = datetime.utcnow().replace(tzinfo=UTC)
+        NOW = datetime.now(timezone.utc)
         LATER = NOW + timedelta(seconds=1)
         TIMESTAMP = _datetime_to_rfc3339_w_nanos(NOW)
         RECEIVED = _datetime_to_rfc3339_w_nanos(LATER)


### PR DESCRIPTION
- Fixed `DeprecationWarning` for datetime objects according to https://docs.python.org/3/library/datetime.html
- Removed `datetime` `DeprecationWarning` from `pytest.ini`

Fixes #818  🦕
