### PR TITLE
fix: Use value of cluster-location in GKE for tagging location

### DIFF
--- a/google/cloud/logging_v2/handlers/_monitored_resources.py
+++ b/google/cloud/logging_v2/handlers/_monitored_resources.py
@@ -61,6 +61,9 @@ _GCE_INSTANCE_ID = "instance/id"
 _GKE_CLUSTER_NAME = "instance/attributes/cluster-name"
 """Attribute in metadata server when in GKE environment."""
 
+_GKE_CLUSTER_LOCATION = "instance/attributes/cluster-location"
+"""Attribute in metadata server when in GKE environment."""
+
 _PROJECT_NAME = "project/project-id"
 """Attribute in metadata server when in GKE environment."""
 
@@ -94,7 +97,7 @@ def _create_kubernetes_resource():
     Returns:
         google.cloud.logging.Resource
     """
-    zone = retrieve_metadata_server(_ZONE_ID)
+    location = retrieve_metadata_server(_GKE_CLUSTER_LOCATION)
     cluster_name = retrieve_metadata_server(_GKE_CLUSTER_NAME)
     project = retrieve_metadata_server(_PROJECT_NAME)
 
@@ -102,7 +105,7 @@ def _create_kubernetes_resource():
         type="k8s_container",
         labels={
             "project_id": project if project else "",
-            "location": zone if zone else "",
+            "location": location if location else "",
             "cluster_name": cluster_name if cluster_name else "",
         },
     )

--- a/tests/unit/handlers/test__monitored_resources.py
+++ b/tests/unit/handlers/test__monitored_resources.py
@@ -56,6 +56,7 @@ class Test_Create_Resources(unittest.TestCase):
         if (
             endpoint == _monitored_resources._ZONE_ID
             or endpoint == _monitored_resources._REGION_ID
+            or endpoint == _monitored_resources._GKE_CLUSTER_LOCATION
         ):
             return self.LOCATION
         elif (


### PR DESCRIPTION
Makes the behavior of the python logging library in this scenario consistent with other loggers, such as the C++ logging library.

Fixes #827 
