### PR TITLE
fix: Allowed for a partial override of loggers that get excluded from setup_client

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -24,13 +24,17 @@ from google.cloud.logging_v2.handlers._helpers import get_request_data
 
 DEFAULT_LOGGER_NAME = "python"
 
-"""Exclude internal logs from propagating through handlers"""
+"""Defaults for filtering out noisy loggers"""
 EXCLUDED_LOGGER_DEFAULTS = (
+    "google.api_core.bidi",
+    "werkzeug",
+)
+
+"""Exclude internal logs from propagating through handlers"""
+_INTERNAL_LOGGERS = (
     "google.cloud",
     "google.auth",
     "google_auth_httplib2",
-    "google.api_core.bidi",
-    "werkzeug",
 )
 
 """These environments require us to remove extra handlers on setup"""
@@ -291,7 +295,7 @@ def setup_logging(
         log_level (Optional[int]): Python logging log level. Defaults to
             :const:`logging.INFO`.
     """
-    all_excluded_loggers = set(excluded_loggers + EXCLUDED_LOGGER_DEFAULTS)
+    all_excluded_loggers = set(excluded_loggers + _INTERNAL_LOGGERS)
     logger = logging.getLogger()
 
     # remove built-in handlers on App Engine or Cloud Functions environments

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -897,7 +897,7 @@ class TestSetupLogging(unittest.TestCase):
         excluded_logger = logging.getLogger(EXCLUDED_LOGGER_NAME)
         self.assertNotIn(handler, excluded_logger.handlers)
         self.assertFalse(excluded_logger.propagate)
-    
+
     def test_setup_logging_internal_loggers_no_excludes(self):
         handler = _Handler(logging.INFO)
         self._call_fut(handler, excludes=())
@@ -908,10 +908,10 @@ class TestSetupLogging(unittest.TestCase):
             logger = logging.getLogger(logger_name)
             self.assertNotIn(handler, logger.handlers)
             self.assertFalse(logger.propagate)
-        
+
         logger = logging.getLogger("logging")
         self.assertTrue(logger.propagate)
-        
+
         for logger_name in EXCLUDED_LOGGER_DEFAULTS:
             logger = logging.getLogger(logger_name)
             self.assertTrue(logger.propagate)
@@ -973,7 +973,6 @@ class TestSetupLogging(unittest.TestCase):
 
         # restore the old logging manager.
         logging.Logger.manager = self._logger_manager
-
 
 
 class _Handler(object):

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -18,6 +18,11 @@ from unittest.mock import patch
 import mock
 import json
 
+from google.cloud.logging_v2.handlers.handlers import (
+    _INTERNAL_LOGGERS,
+    EXCLUDED_LOGGER_DEFAULTS,
+)
+
 from google.cloud.logging_v2.handlers._monitored_resources import (
     _FUNCTION_ENV_VARS,
     _GAE_ENV_VARS,
@@ -867,7 +872,7 @@ class TestSetupLogging(unittest.TestCase):
     def _call_fut(self, handler, excludes=None):
         from google.cloud.logging.handlers import setup_logging
 
-        if excludes:
+        if excludes is not None:
             return setup_logging(handler, excluded_loggers=excludes)
         else:
             return setup_logging(handler)
@@ -892,6 +897,24 @@ class TestSetupLogging(unittest.TestCase):
         excluded_logger = logging.getLogger(EXCLUDED_LOGGER_NAME)
         self.assertNotIn(handler, excluded_logger.handlers)
         self.assertFalse(excluded_logger.propagate)
+    
+    def test_setup_logging_internal_loggers_no_excludes(self):
+        handler = _Handler(logging.INFO)
+        self._call_fut(handler, excludes=())
+
+        # Test that excluded logger defaults can be included, but internal
+        # loggers can't be.
+        for logger_name in _INTERNAL_LOGGERS:
+            logger = logging.getLogger(logger_name)
+            self.assertNotIn(handler, logger.handlers)
+            self.assertFalse(logger.propagate)
+        
+        logger = logging.getLogger("logging")
+        self.assertTrue(logger.propagate)
+        
+        for logger_name in EXCLUDED_LOGGER_DEFAULTS:
+            logger = logging.getLogger(logger_name)
+            self.assertTrue(logger.propagate)
 
     @patch.dict("os.environ", {envar: "1" for envar in _FUNCTION_ENV_VARS})
     def test_remove_handlers_gcf(self):
@@ -939,9 +962,18 @@ class TestSetupLogging(unittest.TestCase):
     def setUp(self):
         self._handlers_cache = logging.getLogger().handlers[:]
 
+        # reset the logging manager every time so that we're not reusing loggers
+        # across different test cases.
+        self._logger_manager = logging.Logger.manager
+        logging.Logger.manager = logging.Manager(logging.Logger.root)
+
     def tearDown(self):
         # cleanup handlers
         logging.getLogger().handlers = self._handlers_cache[:]
+
+        # restore the old logging manager.
+        logging.Logger.manager = self._logger_manager
+
 
 
 class _Handler(object):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -847,9 +847,6 @@ class TestClient(unittest.TestCase):
 
         expected_kwargs = {
             "excluded_loggers": (
-                "google.cloud",
-                "google.auth",
-                "google_auth_httplib2",
                 "google.api_core.bidi",
                 "werkzeug",
             ),
@@ -890,9 +887,6 @@ class TestClient(unittest.TestCase):
 
         expected_kwargs = {
             "excluded_loggers": (
-                "google.cloud",
-                "google.auth",
-                "google_auth_httplib2",
                 "google.api_core.bidi",
                 "werkzeug",
             ),


### PR DESCRIPTION
Separated out `EXCLUDED_LOGGER_DEFAULTS` into `_INTERNAL_LOGGERS` to allow users to override part of the defaults.

Fixes #713 
