### PR TITLE
fix: Added placeholder kwargs to StructuredLogHandler

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -157,7 +157,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         resource=None,
         labels=None,
         stream=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Args:

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -157,6 +157,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         resource=None,
         labels=None,
         stream=None,
+        **kwargs
     ):
         """
         Args:

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -20,7 +20,6 @@ import logging
 import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
-from google.cloud.logging_v2.handlers.handlers import DEFAULT_LOGGER_NAME
 from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
 import google.cloud.logging_v2
 from google.cloud.logging_v2._instrumentation import _create_diagnostic_entry

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -20,6 +20,7 @@ import logging
 import logging.handlers
 
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingFilter
+from google.cloud.logging_v2.handlers.handlers import DEFAULT_LOGGER_NAME
 from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
 import google.cloud.logging_v2
 from google.cloud.logging_v2._instrumentation import _create_diagnostic_entry
@@ -63,10 +64,19 @@ class StructuredLogHandler(logging.StreamHandler):
     """
 
     def __init__(
-        self, *, labels=None, stream=None, project_id=None, json_encoder_cls=None
+        self,
+        *,
+        name=DEFAULT_LOGGER_NAME,
+        resource=None,
+        labels=None,
+        stream=None,
+        project_id=None,
+        json_encoder_cls=None
     ):
         """
         Args:
+            name (Optional[str]): Placeholder for setup_logging consistency. Does nothing.
+            resource (Optional[dict]): Placeholder for setup_logging consistency. Does nothing.
             labels (Optional[dict]): Additional labels to attach to logs.
             stream (Optional[IO]): Stream to be used by the handler.
             project (Optional[str]): Project Id associated with the logs.

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -73,8 +73,6 @@ class StructuredLogHandler(logging.StreamHandler):
     ):
         """
         Args:
-            name (Optional[str]): Placeholder for setup_logging consistency. Does nothing.
-            resource (Optional[dict]): Placeholder for setup_logging consistency. Does nothing.
             labels (Optional[dict]): Additional labels to attach to logs.
             stream (Optional[IO]): Stream to be used by the handler.
             project (Optional[str]): Project Id associated with the logs.

--- a/google/cloud/logging_v2/handlers/structured_log.py
+++ b/google/cloud/logging_v2/handlers/structured_log.py
@@ -66,12 +66,11 @@ class StructuredLogHandler(logging.StreamHandler):
     def __init__(
         self,
         *,
-        name=DEFAULT_LOGGER_NAME,
-        resource=None,
         labels=None,
         stream=None,
         project_id=None,
-        json_encoder_cls=None
+        json_encoder_cls=None,
+        **kwargs
     ):
         """
         Args:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -894,6 +894,42 @@ class TestClient(unittest.TestCase):
         }
         self.assertEqual(kwargs, expected_kwargs)
 
+    def test_setup_logging_w_extra_kwargs_structured_log(self):
+        import io
+        from google.cloud.logging.handlers import StructuredLogHandler
+        from google.cloud.logging import Resource
+        from google.cloud.logging_v2.client import _GKE_RESOURCE_TYPE
+
+        name = "test-logger"
+        resource = Resource(_GKE_RESOURCE_TYPE, {"resource_label": "value"})
+        labels = {"handler_label": "value"}
+        stream = io.BytesIO()
+
+        credentials = _make_credentials()
+        client = self._make_one(
+            project=self.PROJECT, credentials=credentials, _use_grpc=False
+        )
+
+        with mock.patch("google.cloud.logging_v2.client.setup_logging") as mocked:
+            client.setup_logging(
+                name=name, resource=resource, labels=labels, stream=stream
+            )
+
+        self.assertEqual(len(mocked.mock_calls), 1)
+        _, args, kwargs = mocked.mock_calls[0]
+
+        (handler,) = args
+        self.assertIsInstance(handler, StructuredLogHandler)
+
+        expected_kwargs = {
+            "excluded_loggers": (
+                "google.api_core.bidi",
+                "werkzeug",
+            ),
+            "log_level": 20,
+        }
+        self.assertEqual(kwargs, expected_kwargs)
+
 
 class _Connection(object):
     _called_with = None


### PR DESCRIPTION
Added `name` and `resource` as kwargs to `StructuredLogHandler` so that calls to `client.setup_logging` with these kwargs don't crash on unexpected keyword argument exceptions.

Fixes #842 