### PR TITLE
fix: fix TypeError: MessageToJson() got an unexpected keyword argument 'including_default_value_fields' 

### DIFF
--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -271,7 +271,6 @@ class _SinksAPI(object):
         return MessageToDict(
             LogSink.pb(created_pb),
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def sink_get(self, sink_name):
@@ -298,7 +297,6 @@ class _SinksAPI(object):
         return MessageToDict(
             LogSink.pb(sink_pb),
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def sink_update(
@@ -351,7 +349,6 @@ class _SinksAPI(object):
         return MessageToDict(
             LogSink.pb(sink_pb),
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def sink_delete(self, sink_name):
@@ -459,7 +456,6 @@ class _MetricsAPI(object):
         return MessageToDict(
             LogMetric.pb(metric_pb),
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def metric_update(
@@ -496,7 +492,6 @@ class _MetricsAPI(object):
         return MessageToDict(
             LogMetric.pb(metric_pb),
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def metric_delete(self, project, metric_name):
@@ -530,7 +525,6 @@ def _parse_log_entry(entry_pb):
         return MessageToDict(
             entry_pb,
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
     except TypeError:
         if entry_pb.HasField("proto_payload"):
@@ -539,7 +533,6 @@ def _parse_log_entry(entry_pb):
             entry_mapping = MessageToDict(
                 entry_pb,
                 preserving_proto_field_name=False,
-                including_default_value_fields=False,
             )
             entry_mapping["protoPayload"] = proto_payload
             return entry_mapping

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -595,7 +595,6 @@ class Test__parse_log_entry(unittest.TestCase):
         msg_to_dict_mock.assert_called_once_with(
             entry_pb,
             preserving_proto_field_name=False,
-            including_default_value_fields=False,
         )
 
     def test_unregistered_type(self):


### PR DESCRIPTION
This is related to https://github.com/protocolbuffers/protobuf/commit/26995798757fbfef5cf6648610848e389db1fecf and the protobuf 5.x release candidates 
https://pypi.org/project/protobuf/5.26.0rc2/
https://pypi.org/project/protobuf/5.26.0rc3/

Similar to https://github.com/googleapis/gapic-generator-python/pull/1936

See https://github.com/googleapis/gapic-generator-python/issues/1935#issue-2122945007

This should resolve the failure with `Kokoro Prerelease Dependencies` in https://github.com/googleapis/python-logging/pull/846. 