### PR TITLE
fix: Remove extra handlers for Cloud Run on setup

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -38,7 +38,7 @@ _INTERNAL_LOGGERS = (
 )
 
 """These environments require us to remove extra handlers on setup"""
-_CLEAR_HANDLER_RESOURCE_TYPES = ("gae_app", "cloud_function")
+_CLEAR_HANDLER_RESOURCE_TYPES = ("gae_app", "cloud_function", "cloud_run_revision")
 
 """Extra trace label to be added on App Engine environments"""
 _GAE_TRACE_ID_LABEL = "appengine.googleapis.com/trace_id"


### PR DESCRIPTION
setup_logging() does not remove the default handler for Cloud Run environments which leads to duplicate messages and traceback broken up into multiple lines in Cloud Logging

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
