### PR TITLE
docs: Update `dictConfig` snippet

### DIFF
--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -506,8 +506,16 @@ def logging_dict_config(client):
         },
         "root": {"handlers": [], "level": "WARNING"},
         "loggers": {
-            "cloud_logger": {"handlers": ["cloud_logging_handler"], "level": "INFO", "propagate": False},
-            "structured_logger": {"handlers": ["structured_log_handler"], "level": "INFO", "propagate": False},
+            "cloud_logger": {
+                "handlers": ["cloud_logging_handler"],
+                "level": "INFO",
+                "propagate": False,
+            },
+            "structured_logger": {
+                "handlers": ["structured_log_handler"],
+                "level": "INFO",
+                "propagate": False,
+            },
         },
     }
 

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -508,13 +508,11 @@ def logging_dict_config(client):
         "loggers": {
             "cloud_logger": {
                 "handlers": ["cloud_logging_handler"],
-                "level": "INFO",
-                "propagate": False,
+                "level": "INFO"
             },
             "structured_logger": {
                 "handlers": ["structured_log_handler"],
-                "level": "INFO",
-                "propagate": False,
+                "level": "INFO"
             },
         },
     }

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -496,18 +496,18 @@ def logging_dict_config(client):
     LOGGING = {
         "version": 1,
         "handlers": {
-            "cloud_logging": {
+            "cloud_logging_handler": {
                 "class": "google.cloud.logging.handlers.CloudLoggingHandler",
                 "client": client,
             },
-            "structured_log": {
+            "structured_log_handler": {
                 "class": "google.cloud.logging.handlers.StructuredLogHandler"
             },
         },
-        "root": {"handlers": ["cloud_logging", "structured_log"], "level": "WARNING"},
+        "root": {"handlers": [], "level": "WARNING"},
         "loggers": {
-            "my_logger": {"handlers": ["cloud_logging"], "level": "INFO"},
-            "my_other_logger": {"handlers": ["structured_log"], "level": "INFO"},
+            "cloud_logger": {"handlers": ["cloud_logging_handler"], "level": "INFO", "propagate": False},
+            "structured_logger": {"handlers": ["structured_log_handler"], "level": "INFO", "propagate": False},
         },
     }
 

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -486,9 +486,9 @@ def setup_logging(client):
 
 @snippet
 def logging_dict_config(client):
+    # [START logging_dict_config]
     import logging.config
 
-    # [START logging_dict_config]
     import google.cloud.logging
 
     client = google.cloud.logging.Client()

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -510,9 +510,9 @@ def logging_dict_config(client):
             "my_other_logger": {"handlers": ["structured_log"], "level": "INFO"},
         },
     }
-    # [END logging_dict_config]
 
     logging.config.dictConfig(LOGGING)
+    # [END logging_dict_config]
 
 
 def _line_no(func):

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -506,13 +506,10 @@ def logging_dict_config(client):
         },
         "root": {"handlers": [], "level": "WARNING"},
         "loggers": {
-            "cloud_logger": {
-                "handlers": ["cloud_logging_handler"],
-                "level": "INFO"
-            },
+            "cloud_logger": {"handlers": ["cloud_logging_handler"], "level": "INFO"},
             "structured_logger": {
                 "handlers": ["structured_log_handler"],
-                "level": "INFO"
+                "level": "INFO",
             },
         },
     }

--- a/samples/snippets/usage_guide.py
+++ b/samples/snippets/usage_guide.py
@@ -504,7 +504,7 @@ def logging_dict_config(client):
                 "class": "google.cloud.logging.handlers.StructuredLogHandler"
             },
         },
-        "root": {"handlers": ["console"], "level": "WARNING"},
+        "root": {"handlers": ["cloud_logging", "structured_log"], "level": "WARNING"},
         "loggers": {
             "my_logger": {"handlers": ["cloud_logging"], "level": "INFO"},
             "my_other_logger": {"handlers": ["structured_log"], "level": "INFO"},

--- a/samples/snippets/usage_guide_test.py
+++ b/samples/snippets/usage_guide_test.py
@@ -89,6 +89,7 @@ def test_client_list_entries():
     for item in to_delete:
         usage_guide._backoff_not_found(item.delete)
 
+
 def test_dict_config():
     client = Client()
 

--- a/samples/snippets/usage_guide_test.py
+++ b/samples/snippets/usage_guide_test.py
@@ -88,3 +88,8 @@ def test_client_list_entries():
 
     for item in to_delete:
         usage_guide._backoff_not_found(item.delete)
+
+def test_dict_config():
+    client = Client()
+
+    usage_guide.logging_dict_config(client)


### PR DESCRIPTION
The previous `dictConfig` snippet did not include the proper `include logging.config` statement or `logging.config.dictConfig` statement in the snippet as seen in the documentation to actually apply the `dictConfig`. The configuration also did not run properly, failing with traceback

```
Traceback (most recent call last):
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 872, in add_handlers
    logger.addHandler(self.config['handlers'][h])
                      ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 344, in __getitem__
    value = dict.__getitem__(self, key)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'console'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 660, in configure
    self.configure_root(root)
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 906, in configure_root
    self.common_logger_config(root, config, incremental)
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 889, in common_logger_config
    self.add_handlers(logger, handlers)
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 874, in add_handlers
    raise ValueError('Unable to add handler %r' % h) from e
ValueError: Unable to add handler 'console'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 912, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/local/google/home/kevzheng/.pyenv/versions/3.12.0/lib/python3.12/logging/config.py", line 662, in configure
    raise ValueError('Unable to configure root '
ValueError: Unable to configure root logger
```

This PR adds a more realistic sample `dictConfig` that might be used in an actual Cloud environment, while still maintaining how to set up both `CloudLoggingHandler` and `StructuredLogHandler` in `dictConfig` in a Cloud environment.