### PR TITLE
feat!: Use StructuredLogHandler on App Engine instead of CloudLoggingHandler

### DIFF
--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -380,18 +380,21 @@ class Client(ClientWithProject):
             _GAE_RESOURCE_TYPE,
             _GKE_RESOURCE_TYPE,
             _GCF_RESOURCE_TYPE,
-            _RUN_RESOURCE_TYPE
+            _RUN_RESOURCE_TYPE,
         ]
 
-        if isinstance(monitored_resource, Resource) and monitored_resource.type in _structured_log_types:
+        if (
+            isinstance(monitored_resource, Resource)
+            and monitored_resource.type in _structured_log_types
+        ):
             if monitored_resource.type == _GCF_RESOURCE_TYPE:
                 # __stdout__ stream required to support structured logging on Python 3.7
                 kw["stream"] = kw.get("stream", sys.__stdout__)
-            
+
             handler = StructuredLogHandler(**kw, project_id=self.project)
         else:
             handler = CloudLoggingHandler(self, resource=monitored_resource, **kw)
-        
+
         return handler
 
     def setup_logging(

--- a/google/cloud/logging_v2/client.py
+++ b/google/cloud/logging_v2/client.py
@@ -376,18 +376,23 @@ class Client(ClientWithProject):
         """
         monitored_resource = kw.pop("resource", detect_resource(self.project))
 
-        if isinstance(monitored_resource, Resource):
-            if monitored_resource.type == _GAE_RESOURCE_TYPE:
-                return CloudLoggingHandler(self, resource=monitored_resource, **kw)
-            elif monitored_resource.type == _GKE_RESOURCE_TYPE:
-                return StructuredLogHandler(**kw, project_id=self.project)
-            elif monitored_resource.type == _GCF_RESOURCE_TYPE:
+        _structured_log_types = [
+            _GAE_RESOURCE_TYPE,
+            _GKE_RESOURCE_TYPE,
+            _GCF_RESOURCE_TYPE,
+            _RUN_RESOURCE_TYPE
+        ]
+
+        if isinstance(monitored_resource, Resource) and monitored_resource.type in _structured_log_types:
+            if monitored_resource.type == _GCF_RESOURCE_TYPE:
                 # __stdout__ stream required to support structured logging on Python 3.7
                 kw["stream"] = kw.get("stream", sys.__stdout__)
-                return StructuredLogHandler(**kw, project_id=self.project)
-            elif monitored_resource.type == _RUN_RESOURCE_TYPE:
-                return StructuredLogHandler(**kw, project_id=self.project)
-        return CloudLoggingHandler(self, resource=monitored_resource, **kw)
+            
+            handler = StructuredLogHandler(**kw, project_id=self.project)
+        else:
+            handler = CloudLoggingHandler(self, resource=monitored_resource, **kw)
+        
+        return handler
 
     def setup_logging(
         self, *, log_level=logging.INFO, excluded_loggers=EXCLUDED_LOGGER_DEFAULTS, **kw

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -766,7 +766,7 @@ class TestClient(unittest.TestCase):
         import os
         from google.cloud._testing import _Monkey
         from google.cloud.logging_v2.handlers._monitored_resources import _GAE_ENV_VARS
-        from google.cloud.logging.handlers import CloudLoggingHandler
+        from google.cloud.logging.handlers import StructuredLogHandler
 
         credentials = _make_credentials()
         client = self._make_one(
@@ -778,9 +778,7 @@ class TestClient(unittest.TestCase):
         with _Monkey(os, environ=gae_env_vars):
             handler = client.get_default_handler()
 
-        handler.transport.worker.stop()
-
-        self.assertIsInstance(handler, CloudLoggingHandler)
+        self.assertIsInstance(handler, StructuredLogHandler)
 
     def test_get_default_handler_container_engine(self):
         from google.cloud.logging.handlers import StructuredLogHandler


### PR DESCRIPTION
Breaking PR for [go/python-logging-background-thread](http://goto.google.com/python-logging-background-thread).

PR for the rest of the changes involving closing and flushing handlers be included in a separate PR, as will a PR for updating UPGRADING.md.