### PR TITLE
test: Added timestamp to sink names + autodelete sinks older than 2 hours in export_test.py

### DIFF
--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -35,16 +35,17 @@ def _random_id():
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def cleanup_old_sinks():
     client = logging.Client()
-    test_sink_name_regex = TEST_SINK_NAME_TMPL.format('[A-Z0-9]{6}$')
+    test_sink_name_regex = TEST_SINK_NAME_TMPL.format("[A-Z0-9]{6}$")
     for sink in client.list_sinks():
         if re.match(test_sink_name_regex, sink.name):
             try:
                 sink.delete()
             except Exception:
                 pass
+
 
 @pytest.fixture
 def example_sink(cleanup_old_sinks):

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -32,7 +32,7 @@ TIMESTAMP = int(time.time())
 
 # Threshold beyond which the cleanup_old_sinks fixture will delete
 # old sink, in seconds
-CLEANUP_THRESHOLD = 7200 # 2 hours
+CLEANUP_THRESHOLD = 7200  # 2 hours
 
 
 def _random_id():
@@ -51,10 +51,12 @@ def _delete_sink(sink):
 
 
 # Runs once for entire test suite
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def cleanup_old_sinks():
     client = logging.Client()
-    test_sink_name_regex = "^" + TEST_SINK_NAME_TMPL.format("(\d+)","[A-Z0-9]{6}") + "$"
+    test_sink_name_regex = (
+        "^" + TEST_SINK_NAME_TMPL.format("(\d+)", "[A-Z0-9]{6}") + "$"
+    )
     for sink in client.list_sinks():
         match = re.match(test_sink_name_regex, sink.name)
         if match:

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -41,7 +41,10 @@ def cleanup_old_sinks():
     test_sink_name_regex = TEST_SINK_NAME_TMPL.format('[A-Z0-9]{6}$')
     for sink in client.list_sinks():
         if re.match(test_sink_name_regex, sink.name):
-            sink.delete()
+            try:
+                sink.delete()
+            except Exception:
+                pass
 
 @pytest.fixture
 def example_sink(cleanup_old_sinks):
@@ -57,7 +60,10 @@ def example_sink(cleanup_old_sinks):
 
     yield sink
 
-    sink.delete()
+    try:
+        sink.delete()
+    except Exception:
+        pass
 
 
 def test_list(example_sink, capsys):

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -16,6 +16,7 @@ import os
 import re
 import random
 import string
+import time
 
 import backoff
 from google.cloud import logging
@@ -25,8 +26,13 @@ import export
 
 
 BUCKET = os.environ["CLOUD_STORAGE_BUCKET"]
-TEST_SINK_NAME_TMPL = "example_sink_{}"
+TEST_SINK_NAME_TMPL = "example_sink_{}_{}"
 TEST_SINK_FILTER = "severity>=CRITICAL"
+TIMESTAMP = int(time.time())
+
+# Threshold beyond which the cleanup_old_sinks fixture will delete
+# old sink, in seconds
+CLEANUP_THRESHOLD = 7200 # 2 hours
 
 
 def _random_id():
@@ -35,16 +41,26 @@ def _random_id():
     )
 
 
-@pytest.fixture(scope="module")
+def _create_sink_name():
+    return TEST_SINK_NAME_TMPL.format(TIMESTAMP, _random_id())
+
+
+@backoff.on_exception(backoff.expo, Exception, max_time=60)
+def _delete_sink(sink):
+    sink.delete()
+
+
+# Runs once for entire test suite
+@pytest.fixture(scope='module')
 def cleanup_old_sinks():
     client = logging.Client()
-    test_sink_name_regex = TEST_SINK_NAME_TMPL.format("[A-Z0-9]{6}$")
+    test_sink_name_regex = "^" + TEST_SINK_NAME_TMPL.format("(\d+)","[A-Z0-9]{6}") + "$"
     for sink in client.list_sinks():
-        if re.match(test_sink_name_regex, sink.name):
-            try:
-                sink.delete()
-            except Exception:
-                pass
+        match = re.match(test_sink_name_regex, sink.name)
+        if match:
+            sink_timestamp = int(match.group(1))
+            if TIMESTAMP - sink_timestamp > CLEANUP_THRESHOLD:
+                _delete_sink(sink)
 
 
 @pytest.fixture
@@ -52,7 +68,7 @@ def example_sink(cleanup_old_sinks):
     client = logging.Client()
 
     sink = client.sink(
-        TEST_SINK_NAME_TMPL.format(_random_id()),
+        _create_sink_name(),
         filter_=TEST_SINK_FILTER,
         destination="storage.googleapis.com/{bucket}".format(bucket=BUCKET),
     )
@@ -61,10 +77,7 @@ def example_sink(cleanup_old_sinks):
 
     yield sink
 
-    try:
-        sink.delete()
-    except Exception:
-        pass
+    _delete_sink(sink)
 
 
 def test_list(example_sink, capsys):
@@ -78,16 +91,13 @@ def test_list(example_sink, capsys):
 
 
 def test_create(capsys):
-    sink_name = TEST_SINK_NAME_TMPL.format(_random_id())
+    sink_name = _create_sink_name()
 
     try:
         export.create_sink(sink_name, BUCKET, TEST_SINK_FILTER)
     # Clean-up the temporary sink.
     finally:
-        try:
-            logging.Client().sink(sink_name).delete()
-        except Exception:
-            pass
+        _delete_sink(logging.Client().sink(sink_name))
 
     out, _ = capsys.readouterr()
     assert sink_name in out

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -55,7 +55,7 @@ def _delete_sink(sink):
 def cleanup_old_sinks():
     client = logging.Client()
     test_sink_name_regex = (
-        r"^" + TEST_SINK_NAME_TMPL.format(r"(\d+)",r"[A-Z0-9]{6}") + r"$"
+        r"^" + TEST_SINK_NAME_TMPL.format(r"(\d+)", r"[A-Z0-9]{6}") + r"$"
     )
     for sink in client.list_sinks():
         match = re.match(test_sink_name_regex, sink.name)

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -45,7 +45,7 @@ def _create_sink_name():
     return TEST_SINK_NAME_TMPL.format(TIMESTAMP, _random_id())
 
 
-@backoff.on_exception(backoff.expo, Exception, max_time=60)
+@backoff.on_exception(backoff.expo, Exception, max_time=60, raise_on_giveup=False)
 def _delete_sink(sink):
     sink.delete()
 
@@ -55,7 +55,7 @@ def _delete_sink(sink):
 def cleanup_old_sinks():
     client = logging.Client()
     test_sink_name_regex = (
-        "^" + TEST_SINK_NAME_TMPL.format("(\d+)", "[A-Z0-9]{6}") + "$"
+        r"^" + TEST_SINK_NAME_TMPL.format(r"(\d+)",r"[A-Z0-9]{6}") + r"$"
     )
     for sink in client.list_sinks():
         match = re.match(test_sink_name_regex, sink.name)

--- a/samples/snippets/export_test.py
+++ b/samples/snippets/export_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import random
 import string
 
@@ -34,8 +35,16 @@ def _random_id():
     )
 
 
+@pytest.fixture(scope='module')
+def cleanup_old_sinks():
+    client = logging.Client()
+    test_sink_name_regex = TEST_SINK_NAME_TMPL.format('[A-Z0-9]{6}$')
+    for sink in client.list_sinks():
+        if re.match(test_sink_name_regex, sink.name):
+            sink.delete()
+
 @pytest.fixture
-def example_sink():
+def example_sink(cleanup_old_sinks):
     client = logging.Client()
 
     sink = client.sink(
@@ -48,10 +57,7 @@ def example_sink():
 
     yield sink
 
-    try:
-        sink.delete()
-    except Exception:
-        pass
+    sink.delete()
 
 
 def test_list(example_sink, capsys):


### PR DESCRIPTION
Added a timestamp field in `TEST_SINK_NAME_IMPL` and a cleanup threshold so that the `export_test.py` test suite deletes sinks older than 2 hours when run.

Also added exponential backoff to sink deletion to reduce the chances of sink deletion failure.

Fixes #923 
