### PR TITLE
fix: Fixed type hinting issue with specifying Transport class

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -157,7 +157,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         client,
         *,
         name: str = DEFAULT_LOGGER_NAME,
-        transport: Transport = BackgroundThreadTransport,
+        transport: type[Transport] = BackgroundThreadTransport,
         resource: Resource = None,
         labels: Optional[dict] = None,
         stream: Optional[IO] = None,

--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -18,7 +18,7 @@ import collections
 import json
 import logging
 
-from typing import Optional, IO
+from typing import Optional, IO, Type
 
 from google.cloud.logging_v2.handlers.transports import (
     BackgroundThreadTransport,
@@ -157,7 +157,7 @@ class CloudLoggingHandler(logging.StreamHandler):
         client,
         *,
         name: str = DEFAULT_LOGGER_NAME,
-        transport: type[Transport] = BackgroundThreadTransport,
+        transport: Type[Transport] = BackgroundThreadTransport,
         resource: Resource = None,
         labels: Optional[dict] = None,
         stream: Optional[IO] = None,


### PR DESCRIPTION
We're not passing in an object of type `Transport` in the constructor, we're passing in a class name that subclasses `Transport` so that it gets created.

Fixes #929 
