### PR TITLE
build: update constraints files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -143,12 +143,12 @@ Running System Tests
    $ nox -s system
 
    # Run a single system test
-   $ nox -s system-3.8 -- -k <name of test>
+   $ nox -s system-3.12 -- -k <name of test>
 
 
   .. note::
 
-      System tests are only configured to run under Python 3.8.
+      System tests are only configured to run under Python 3.12.
       For expediency, we do not run them in older versions of Python 3.
 
   This alone will not run the tests. You'll need to change some local

--- a/noxfile.py
+++ b/noxfile.py
@@ -419,6 +419,7 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*constraints_deps)
 
     prerel_deps = [
+        "google-cloud-audit-log",
         "protobuf",
         # dependency of grpc
         "six",

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.12"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/owlbot.py
+++ b/owlbot.py
@@ -94,6 +94,7 @@ templated_files = gcp.CommonTemplates().py_library(
         "google-cloud-testutils",
         "opentelemetry-sdk"
     ],
+    system_test_python_versions=["3.12"],
     unit_test_external_dependencies=["flask", "webob", "django"],
     samples=True,
 )

--- a/owlbot.py
+++ b/owlbot.py
@@ -69,6 +69,7 @@ for library in s.get_staging_dirs(default_version):
             "setup.py",
             "testing/constraints-3.7.txt",
             "testing/constraints-3.8.txt",
+            "testing/constraints-3.9.txt",
             "README.rst",
             "google/cloud/logging/__init__.py",  # generated types are hidden from users
             "google/cloud/logging_v2/__init__.py",

--- a/owlbot.py
+++ b/owlbot.py
@@ -67,9 +67,7 @@ for library in s.get_staging_dirs(default_version):
     s.move([library], excludes=[
             "**/gapic_version.py",
             "setup.py",
-            "testing/constraints-3.7.txt",
-            "testing/constraints-3.8.txt",
-            "testing/constraints-3.9.txt",
+            "testing/constraints*.txt",
             "README.rst",
             "google/cloud/logging/__init__.py",  # generated types are hidden from users
             "google/cloud/logging_v2/__init__.py",

--- a/owlbot.py
+++ b/owlbot.py
@@ -109,6 +109,13 @@ s.move(templated_files,
         "README.rst", # This repo has a customized README
     ],
 )
+s.replace("noxfile.py",
+"""prerel_deps = \[
+        "protobuf",""",
+"""prerel_deps = [
+        "google-cloud-audit-log",
+        "protobuf",""",
+)
 
 # adjust .trampolinerc for environment tests
 s.replace(".trampolinerc", "required_envvars[^\)]*\)", "required_envvars+=()")

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dependencies = [
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
     "google-cloud-appengine-logging>=0.1.0, <2.0.0dev",
-    "google-cloud-audit-log >= 0.1.0, < 1.0.0dev",
+    "google-cloud-audit-log >= 0.1.1, < 1.0.0dev",
     "google-cloud-core >= 2.0.0, <3.0.0dev",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0dev",
     "opentelemetry-api >= 1.0.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ dependencies = [
     "google-cloud-audit-log >= 0.1.1, < 1.0.0dev",
     "google-cloud-core >= 2.0.0, <3.0.0dev",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0dev",
-    "opentelemetry-api >= 1.0.0",
+    "opentelemetry-api >= 1.9.0",
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
     "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dependencies = [
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
     "google-cloud-appengine-logging>=0.1.3, <2.0.0dev",
-    "google-cloud-audit-log >= 0.1.1, < 1.0.0dev",
+    "google-cloud-audit-log >= 0.2.4, < 1.0.0dev",
     "google-cloud-core >= 2.0.0, <3.0.0dev",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0dev",
     "opentelemetry-api >= 1.9.0",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",
-    "google-cloud-appengine-logging>=0.1.0, <2.0.0dev",
+    "google-cloud-appengine-logging>=0.1.3, <2.0.0dev",
     "google-cloud-audit-log >= 0.1.1, < 1.0.0dev",
     "google-cloud-core >= 2.0.0, <3.0.0dev",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0dev",

--- a/testing/constraints-3.10.txt
+++ b/testing/constraints-3.10.txt
@@ -2,5 +2,15 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 proto-plus
 protobuf
+google-cloud-core
+google-cloud-appengine-logging
+google-cloud-audit-log
+grpc-google-iam-v1
+opentelemetry-api
+
+# optional dependencies
+django
+flask

--- a/testing/constraints-3.11.txt
+++ b/testing/constraints-3.11.txt
@@ -2,5 +2,15 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 proto-plus
 protobuf
+google-cloud-core
+google-cloud-appengine-logging
+google-cloud-audit-log
+grpc-google-iam-v1
+opentelemetry-api
+
+# optional dependencies
+django
+flask

--- a/testing/constraints-3.12.txt
+++ b/testing/constraints-3.12.txt
@@ -2,5 +2,15 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 proto-plus
 protobuf
+google-cloud-core
+google-cloud-appengine-logging
+google-cloud-audit-log
+grpc-google-iam-v1
+opentelemetry-api
+
+# optional dependencies
+django
+flask

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -10,7 +10,7 @@ proto-plus==1.22.0
 protobuf==3.20.2
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.3
-google-cloud-audit-log==0.1.1
+google-cloud-audit-log==0.2.4
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0
 

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -9,7 +9,7 @@ google-auth==2.14.1
 proto-plus==1.22.0
 protobuf==3.20.2
 google-cloud-core==2.0.0
-google-cloud-appengine-logging==0.1.0
+google-cloud-appengine-logging==0.1.3
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -10,7 +10,7 @@ proto-plus==1.22.0
 protobuf==3.20.2
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
-google-cloud-audit-log==0.1.0
+google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.0.0
 

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -12,7 +12,7 @@ google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
-opentelemetry-api==1.0.0
+opentelemetry-api==1.9.0
 
 # Lower bound testing for optional dependencies
 django==3.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -9,6 +9,10 @@ google-auth==2.14.1
 proto-plus==1.22.0
 protobuf==3.20.2
 google-cloud-core==2.0.0
+google-cloud-appengine-logging==0.1.0
+google-cloud-audit-log==0.1.0
+grpc-google-iam-v1==0.12.4
+opentelemetry-api==1.0.0
 
 # Lower bound testing for optional dependencies
 django==3.2

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -6,7 +6,7 @@ google-auth==2.14.1
 proto-plus==1.22.0
 protobuf==4.21.6
 google-cloud-core==2.0.0
-google-cloud-appengine-logging==0.1.0
+google-cloud-appengine-logging==0.1.3
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -2,5 +2,11 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core==2.14.0
-proto-plus
-protobuf
+google-auth==2.14.1
+proto-plus==1.22.0
+protobuf==4.21.6
+google-cloud-core==2.0.0
+google-cloud-appengine-logging==0.1.0
+google-cloud-audit-log==0.1.0
+grpc-google-iam-v1==0.12.4
+opentelemetry-api==1.0.0

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -10,3 +10,13 @@ google-cloud-appengine-logging==0.1.0
 google-cloud-audit-log==0.1.0
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.0.0
+
+# Lower bound testing for optional dependencies
+django==3.2
+
+# Need specific versions of Flask dependencies for Flask 1.0 to work
+flask==1.0.0
+jinja2==2.10.1
+markupsafe==2.0.1
+itsdangerous==2.0.1
+werkzeug==1.0.1

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -9,7 +9,7 @@ google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
-opentelemetry-api==1.0.0
+opentelemetry-api==1.9.0
 
 # Lower bound testing for optional dependencies
 django==3.2

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -7,7 +7,7 @@ proto-plus==1.22.0
 protobuf==4.21.6
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
-google-cloud-audit-log==0.1.0
+google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.0.0
 

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -7,7 +7,7 @@ proto-plus==1.22.0
 protobuf==4.21.6
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.3
-google-cloud-audit-log==0.1.1
+google-cloud-audit-log==0.2.4
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0
 

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -7,7 +7,7 @@ proto-plus==1.22.0
 protobuf==5.26.0
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.3
-google-cloud-audit-log==0.1.1
+google-cloud-audit-log==0.2.4
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0
 

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -6,7 +6,7 @@ google-auth==2.14.1
 proto-plus==1.22.0
 protobuf==5.26.0
 google-cloud-core==2.0.0
-google-cloud-appengine-logging==0.1.0
+google-cloud-appengine-logging==0.1.3
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.9.0

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
-google-api-core==2.14.0
-google-auth==2.14.1
-proto-plus==1.22.0
+google-api-core
+google-auth
+proto-plus
 protobuf==5.26.0
-google-cloud-core==2.0.0
-google-cloud-appengine-logging==0.1.3
-google-cloud-audit-log==0.2.4
-grpc-google-iam-v1==0.12.4
+google-cloud-core
+google-cloud-appengine-logging
+google-cloud-audit-log
+grpc-google-iam-v1
 opentelemetry-api==1.9.0
 
 # Lower bound testing for optional dependencies

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -4,7 +4,7 @@
 google-api-core
 google-auth
 proto-plus
-protobuf==5.26.0
+protobuf
 google-cloud-core
 google-cloud-appengine-logging
 google-cloud-audit-log

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -10,3 +10,13 @@ google-cloud-appengine-logging==0.1.0
 google-cloud-audit-log==0.1.0
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.0.0
+
+# Lower bound testing for optional dependencies
+django==3.2
+
+# Need specific versions of Flask dependencies for Flask 1.0 to work
+flask==1.0.0
+jinja2==2.10.1
+markupsafe==2.0.1
+itsdangerous==2.0.1
+werkzeug==1.0.1

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+google-api-core==2.14.0
+google-auth==2.14.1
+proto-plus==1.22.0
+protobuf==5.26.0
+google-cloud-core==2.0.0
+google-cloud-appengine-logging==0.1.0
+google-cloud-audit-log==0.1.0
+grpc-google-iam-v1==0.12.4
+opentelemetry-api==1.0.0

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -9,7 +9,7 @@ google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
 google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
-opentelemetry-api==1.0.0
+opentelemetry-api==1.9.0
 
 # Lower bound testing for optional dependencies
 django==3.2

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -7,7 +7,7 @@ proto-plus==1.22.0
 protobuf==5.26.0
 google-cloud-core==2.0.0
 google-cloud-appengine-logging==0.1.0
-google-cloud-audit-log==0.1.0
+google-cloud-audit-log==0.1.1
 grpc-google-iam-v1==0.12.4
 opentelemetry-api==1.0.0
 


### PR DESCRIPTION
Towards https://github.com/googleapis/python-logging/issues/934

BEGIN_COMMIT_OVERRIDE
fix(deps): require opentelemetry-api>=1.9.0
fix(deps): require google-cloud-appengine-logging>=0.1.3
fix(deps): require google-cloud-audit-log >= 0.2.4
END_COMMIT_OVERRIDE