### PR TITLE
fix: Made `write_entries` raise `ValueError` on `ParseError`s

### DIFF
--- a/google/cloud/logging_v2/_gapic.py
+++ b/google/cloud/logging_v2/_gapic.py
@@ -30,6 +30,7 @@ from google.cloud.logging_v2.types import LogEntry as LogEntryPB
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import ParseDict
+from google.protobuf.json_format import ParseError
 
 from google.cloud.logging_v2._helpers import entry_from_resource
 from google.cloud.logging_v2.sink import Sink
@@ -151,7 +152,10 @@ class _LoggingAPI(object):
                 Useful for checking whether the logging API endpoints are working
                 properly before sending valuable data.
         """
-        log_entry_pbs = [_log_entry_mapping_to_pb(entry) for entry in entries]
+        try:
+            log_entry_pbs = [_log_entry_mapping_to_pb(entry) for entry in entries]
+        except ParseError as e:
+            raise ValueError(f"Invalid log entry: {str(e)}") from e
 
         request = WriteLogEntriesRequest(
             log_name=logger_name,

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -206,12 +206,22 @@ class Logger(object):
         See
         https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write
 
-        The dictionary entry must be able to be serializable to a Protobuf Struct
-        (see https://protobuf.dev/reference/protobuf/google.protobuf/#value for more
-        details), otherwise it will not be logged, and a :class:`ValueError` will be raised.
+        The message must be able to be serializable to a Protobuf Struct.
+        It must be a dictionary of strings to one of the following:
+
+            - :class:`str`
+            - :class:`int`
+            - :class:`float`
+            - :class:`bool`
+            - :class:`list[str|float|int|bool|list|dict|None]`
+            - :class:`dict[str, str|float|int|bool|list|dict|None]`
+
+        For more details on Protobuf structs, see https://protobuf.dev/reference/protobuf/google.protobuf/#value.
+        If the provided dictionary cannot be serialized into a Protobuf struct,
+        it will not be logged, and a :class:`ValueError` will be raised.
 
         Args:
-            info (dict[str|float|int|bool|list|dict|None]):
+            info (dict[str, str|float|int|bool|list|dict|None]):
                 the log entry information.
             client (Optional[~logging_v2.client.Client]):
                 The client to use.  If not passed, falls back to the
@@ -416,13 +426,22 @@ class Batch(object):
     def log_struct(self, info, **kw):
         """Add a struct entry to be logged during :meth:`commit`.
 
-        The dictionary entry must be able to be serializable to a Protobuf Struct
-        (see https://protobuf.dev/reference/protobuf/google.protobuf/#value for more
-        details), otherwise it will not be logged and a :class:`ValueError` will be
-        raised during :meth:`commit`.
+        The message must be able to be serializable to a Protobuf Struct.
+        It must be a dictionary of strings to one of the following:
+
+            - :class:`str`
+            - :class:`int`
+            - :class:`float`
+            - :class:`bool`
+            - :class:`list[str|float|int|bool|list|dict|None]`
+            - :class:`dict[str, str|float|int|bool|list|dict|None]`
+
+        For more details on Protobuf structs, see https://protobuf.dev/reference/protobuf/google.protobuf/#value.
+        If the provided dictionary cannot be serialized into a Protobuf struct,
+        it will not be logged, and a :class:`ValueError` will be raised during :meth:`commit`.
 
         Args:
-            info (dict): The struct entry,
+            info (dict[str, str|float|int|bool|list|dict|None]): The struct entry,
             kw (Optional[dict]): Additional keyword arguments for the entry.
                 See :class:`~logging_v2.entries.LogEntry`.
         """

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -208,7 +208,7 @@ class Logger(object):
 
         The dictionary entry must be able to be serializable to a Protobuf Struct
         (see https://protobuf.dev/reference/protobuf/google.protobuf/#value for more
-        details), otherwise it will not be logged.
+        details), otherwise it will not be logged, and a :class:`ValueError` will be raised.
 
         Args:
             info (dict[str|float|int|bool|list|dict|None]):

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -215,7 +215,8 @@ class Logger(object):
             info (dict):
                 the log entry information. The dict must be serializable
                 to a Protobuf Struct (map from strings to Values, see
-                https://protobuf.dev/reference/protobuf/google.protobuf/#value).
+                https://protobuf.dev/reference/protobuf/google.protobuf/#value),
+                otherwise the item will not be logged.
             client (Optional[~logging_v2.client.Client]):
                 The client to use.  If not passed, falls back to the
                 ``client`` stored on the current sink.

--- a/google/cloud/logging_v2/logger.py
+++ b/google/cloud/logging_v2/logger.py
@@ -218,7 +218,7 @@ class Logger(object):
                 ``client`` stored on the current sink.
             kw (Optional[dict]): additional keyword arguments for the entry.
                 See :class:`~logging_v2.entries.LogEntry`.
-        
+
         Raises:
             ValueError:
                 if the dictionary message provided cannot be serialized into a Protobuf
@@ -467,7 +467,7 @@ class Batch(object):
                 Whether a batch's valid entries should be written even
                 if some other entry failed due to a permanent error such
                 as INVALID_ARGUMENT or PERMISSION_DENIED.
-        
+
         Raises:
             ValueError:
                 if one of the messages in the batch cannot be successfully parsed.

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -17,6 +17,8 @@ import unittest
 import google.auth.credentials
 import mock
 
+from datetime import datetime
+
 import google.cloud.logging
 from google.cloud import logging_v2
 from google.cloud.logging_v2 import _gapic
@@ -172,6 +174,21 @@ class Test_LoggingAPI(unittest.TestCase):
         assert request.entries[0].log_name == entry["logName"]
         assert request.entries[0].resource.type == entry["resource"]["type"]
         assert request.entries[0].text_payload == "text"
+
+    def test_write_entries_parse_error(self):
+        client = self.make_logging_api()
+        with self.assertRaises(ValueError):
+            with mock.patch.object(
+                type(client._gapic_api.transport.write_log_entries), "__call__"
+            ) as call:
+                entry = {
+                    "logName": self.LOG_PATH,
+                    "resource": {"type": "global"},
+                    "jsonPayload": {"time": datetime.now()},
+                }
+                client.write_entries([entry])
+        
+        call.assert_not_called()
 
     def test_logger_delete(self):
         client = self.make_logging_api()

--- a/tests/unit/test__gapic.py
+++ b/tests/unit/test__gapic.py
@@ -187,7 +187,7 @@ class Test_LoggingAPI(unittest.TestCase):
                     "jsonPayload": {"time": datetime.now()},
                 }
                 client.write_entries([entry])
-        
+
         call.assert_not_called()
 
     def test_logger_delete(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -349,7 +349,6 @@ class TestLogger(unittest.TestCase):
             exception_cls, _, _ = log.records[0].exc_info
             self.assertEqual(exception_cls, ParseError)
 
-
     def test_log_nested_struct(self):
         from google.cloud.logging_v2.handlers._monitored_resources import (
             detect_resource,
@@ -1882,7 +1881,9 @@ class TestBatch(unittest.TestCase):
 
             # Check that we have logged the right message
             exc_info_exception = exc_info[1]
-            self.assertEqual(exc_info_exception.message, f"{starting_message}: {str(api_entry)}...")
+            self.assertEqual(
+                exc_info_exception.message, f"{starting_message}: {str(api_entry)}..."
+            )
 
 
 class _Logger(object):
@@ -1964,7 +1965,6 @@ class _DummyLoggingAPIGapicMockedOnly(_LoggingAPI):
             labels=labels,
             partial_success=partial_success,
         )
-
 
 
 class _Client(object):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1842,20 +1842,7 @@ class TestBatch(unittest.TestCase):
             batch.commit()
             expected_log = test_entries[1]
             api_entry = expected_log.to_api_repr()
-<<<<<<< HEAD
-            self.assertEqual(len(log.records), 1)
-
-            exc_info = log.records[0].exc_info
-            self.assertTrue(exc_info)
-
-            # Check that we have logged the right message
-            exc_info_exception = exc_info[1]
-            self.assertEqual(
-                exc_info_exception.message, f"{starting_message}: {str(api_entry)}..."
-            )
-=======
             self.assertEqual(e.message, f"{starting_message}: {str(api_entry)}...")
->>>>>>> 4751200 (Made write_entries raise ValueError on ParseErrors)
 
 
 class _Logger(object):
@@ -1908,40 +1895,6 @@ class _DummyLoggingExceptionAPI(object):
         raise self.exception
 
 
-<<<<<<< HEAD
-class _DummyLoggingAPIGapicMockedOnly(_LoggingAPI):
-    _write_entries_called_with = None
-
-    def __init__(self, client):
-        super(_DummyLoggingAPIGapicMockedOnly, self).__init__(mock.Mock(), client)
-
-    def write_entries(
-        self,
-        entries,
-        *,
-        logger_name=None,
-        resource=None,
-        labels=None,
-        partial_success=False,
-    ):
-        self._write_entries_called_with = (
-            entries,
-            logger_name,
-            resource,
-            labels,
-            partial_success,
-        )
-        super(_DummyLoggingAPIGapicMockedOnly, self).write_entries(
-            entries,
-            logger_name=logger_name,
-            resource=resource,
-            labels=labels,
-            partial_success=partial_success,
-        )
-
-
-=======
->>>>>>> 4751200 (Made write_entries raise ValueError on ParseErrors)
 class _Client(object):
     def __init__(self, project, connection=None):
         self.project = project

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -16,7 +16,6 @@ import sys
 import unittest
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
-from google.cloud.logging_v2._gapic import _LoggingAPI
 
 import mock
 import pytest


### PR DESCRIPTION
Two fixes for #943:

1. Made `write_entries` raise `ValueError` on invalid log entries.
2. Added documentation clarifying the expected format of `log_struct` and clarifying the `ValueError` that gets raised.