### PR TITLE
fix: make atexit registration conditional on background transport

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -188,7 +188,7 @@ class CloudLoggingHandler(logging.StreamHandler):
             resource = detect_resource(client.project)
         self.name = name
         self.client = client
-        self.transport = transport(client, name, resource=resource)
+        self.transport = transport(client, name, resource=resource, **kwargs)
         self.project_id = client.project
         self.resource = resource
         self.labels = labels


### PR DESCRIPTION
The background transport fails on Python 3.12 when working with gRPC in case there are messages in the queue when the Python interpreter exits. Making the registration of the atexit callback conditional so that users can circumvent this error by explicitly stopping the logging when their application terminates.

We can consider making the default value depend on the Python version at runtime, but it was decided to not change the default behaviour, regardless of the Python version.

Fixes googleapis/google-cloud-python#15408 and googleapis/python-logging#855 (if users would setup the logging disabling the atexit hook).
