### PR TITLE
fix: make logging handler close conditional to having the transport opened

### DIFF
--- a/google/cloud/logging_v2/handlers/handlers.py
+++ b/google/cloud/logging_v2/handlers/handlers.py
@@ -245,9 +245,10 @@ class CloudLoggingHandler(logging.StreamHandler):
 
     def close(self):
         """Closes the log handler and cleans up all Transport objects used."""
-        self.transport.close()
-        self.transport = None
-        self._transport_open = False
+        if self._transport_open:
+            self.transport.close()
+            self.transport = None
+            self._transport_open = False
 
 
 def _format_and_parse_message(record, formatter_handler):

--- a/tests/unit/handlers/test_handlers.py
+++ b/tests/unit/handlers/test_handlers.py
@@ -901,6 +901,10 @@ class TestCloudLoggingHandler(unittest.TestCase):
         self.assertFalse(handler._transport_open)
         self.assertTrue(old_transport.close_called)
 
+        # second call to close shouldn't throw an exception
+        handler.close()
+        self.assertFalse(handler._transport_open)
+
 
 class TestFormatAndParseMessage(unittest.TestCase):
     def test_none(self):


### PR DESCRIPTION
There was a recent release (3.12.0) that included the changes introduced in #917. The newly introduced close method seems to be called by AppEngine Python runtime at shutdown, so if you would call it explicitly before the runtime does it, then the close function throws an exception because transport is None.

Fixes #989
