### PR TITLE
test: ignore DeprecationWarning for `credentials_file` argument and Python versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.9",

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,6 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.8"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
-    "3.7",
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,9 +20,9 @@ filterwarnings =
     # 3.8 deprecation warnings, remove after support for Python 3.8 is dropped
     ignore:You are using a non-supported Python version \(3\.8:FutureWarning
     # 3.9 deprecation warnings, remove after support for Python 3.9 is dropped
-    ignore:: You are using a Python version \(3\.9:FutureWarning
+    ignore:You are using a Python version \(3\.9:FutureWarning
     # 3.10 deprecation warnings, remove after support for Python 3.10 is dropped
-    ignore:: You are using a Python version \(3\.10:FutureWarning
+    ignore:You are using a Python version \(3\.10:FutureWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working:DeprecationWarning
     # 3.12 deprecation warnings, remove after support for Python 3.12 is dropped
     ignore:Attribute s is deprecated and will be removed in Python 3.14; use value instead:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,17 +9,22 @@ filterwarnings =
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
     # Remove warning once https://github.com/grpc/grpc/issues/35974 is fixed
     ignore:unclosed:ResourceWarning
-    # Remove after support for Python 3.7 is dropped
-    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     # Remove warning once https://github.com/googleapis/gapic-generator-python/issues/1939 is fixed
     ignore:get_mtls_endpoint_and_cert_source is deprecated.:DeprecationWarning
     # DeprecationWarnings triggered by Flask 1.0 testing by Flask dependencies in test code
-    # 3.7 deprecation warnings 
+    ignore:Importing 'itsdangerous.json' is deprecated and will be removed in ItsDangerous 2.1:DeprecationWarning
+    # 3.7 deprecation warnings, remove after support for Python 3.7 is dropped
+    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning
-    # 3.8 - 3.9 deprecation warnings
-    ignore:Importing 'itsdangerous.json' is deprecated and will be removed in ItsDangerous 2.1. Use Python's 'json' module instead.:DeprecationWarning
+    ignore:You are using a non-supported Python version \(3\.7:FutureWarning
+    # 3.8 deprecation warnings, remove after support for Python 3.8 is dropped
+    ignore:You are using a non-supported Python version \(3\.8:FutureWarning
+    # 3.9 deprecation warnings, remove after support for Python 3.9 is dropped
+    ignore:: You are using a Python version \(3\.9:FutureWarning
+    # 3.10 deprecation warnings, remove after support for Python 3.10 is dropped
+    ignore:: You are using a Python version \(3\.10:FutureWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working:DeprecationWarning
-    # 3.12 deprecation warnings
+    # 3.12 deprecation warnings, remove after support for Python 3.12 is dropped
     ignore:Attribute s is deprecated and will be removed in Python 3.14; use value instead:DeprecationWarning
     ignore:ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead:DeprecationWarning
     ignore:'pkgutil.get_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec\(\) instead:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -27,3 +27,5 @@ filterwarnings =
     ignore:.*Please use message_factory.GetMessageClass\(\) instead. SymbolDatabase.GetPrototype\(\) will be removed soon.:UserWarning
     # Remove warning once https://github.com/googleapis/gapic-generator-python/issues/2046 is fixed
     ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
+    # Remove when `credentials_file` argument is removed
+    ignore:The `credentials_file` argument is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -34,3 +34,5 @@ filterwarnings =
     ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning
     # Remove when `credentials_file` argument is removed
     ignore:The `credentials_file` argument is deprecated:DeprecationWarning
+    # Remove when load_credentials_from_file method is removed
+    ignore:The load_credentials_from_file method is deprecated:DeprecationWarning


### PR DESCRIPTION
closes #1034
closes #1030
closes #1026 
closes #1024
closes #1021
closes #1020
closes #1018
closes #1017
closes #1016
closes #1014
closes #1006
closes #1005
closes #1004
