### PR TITLE
chore: librarian release pull request: 20251120T132402Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
 libraries:
   - id: google-cloud-logging
-    version: 3.12.1
+    version: 3.13.0
     last_generated_commit: 5400ccce473c439885bd6bf2924fd242271bfcab
     apis:
       - path: google/logging/v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-logging/#history
 
+## [3.13.0](https://github.com/googleapis/python-logging/compare/v3.12.1...v3.13.0) (2025-11-20)
+
+
+### Bug Fixes
+
+* remove setup.cfg configuration for creating universal wheels (#981) ([70f612c3281f1df13f3aba6b19bc4e9397297f3d](https://github.com/googleapis/python-logging/commit/70f612c3281f1df13f3aba6b19bc4e9397297f3d))
+
 ## [3.12.1](https://github.com/googleapis/python-logging/compare/v3.12.0...v3.12.1) (2025-04-21)
 
 

--- a/google/cloud/logging/gapic_version.py
+++ b/google/cloud/logging/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.12.1"  # {x-release-please-version}
+__version__ = "3.13.0"  # {x-release-please-version}

--- a/google/cloud/logging_v2/gapic_version.py
+++ b/google/cloud/logging_v2/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.12.1"  # {x-release-please-version}
+__version__ = "3.13.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.logging.v2.json
+++ b/samples/generated_samples/snippet_metadata_google.logging.v2.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-logging",
-    "version": "3.12.1"
+    "version": "3.13.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
<details><summary>google-cloud-logging: 3.13.0</summary>

## [3.13.0](https://github.com/googleapis/python-logging/compare/v3.12.1...v3.13.0) (2025-11-20)

### Bug Fixes

* remove setup.cfg configuration for creating universal wheels (#981) ([70f612c3](https://github.com/googleapis/python-logging/commit/70f612c3))

</details>