### PR TITLE
chore: remove 3.9 from kokoro tests

### DIFF
--- a/.librarian/generator-input/noxfile.py
+++ b/.librarian/generator-input/noxfile.py
@@ -80,7 +80,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,7 +84,6 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit-3.9",
     "unit-3.10",
     "unit-3.11",
     "unit-3.12",


### PR DESCRIPTION
Similar to https://github.com/googleapis/python-firestore/pull/1163 . Python 3.9 tests will run in Github actions after the migration to google-cloud-python.